### PR TITLE
Add app config, systemd autostart and auto-connect

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -18,6 +18,8 @@ find_package(Qt6 COMPONENTS
 
 set(SOURCES
         main.cpp
+        appconfig.h
+        appconfig.cpp
         vpnmanager.h
         vpnmanager.cpp
         mainwindow.h

--- a/src/appconfig.cpp
+++ b/src/appconfig.cpp
@@ -1,0 +1,61 @@
+#include "appconfig.h"
+
+#include <QDir>
+#include <QFile>
+#include <QJsonDocument>
+#include <QJsonObject>
+
+// ── Easy-to-change config location ──────────────────────────────────────────
+static const QString kConfigDir  = QDir::homePath() + QStringLiteral("/.config/ProtonVPN-Qt");
+static const QString kConfigFile = kConfigDir + QStringLiteral("/app.json");
+// ────────────────────────────────────────────────────────────────────────────
+
+AppConfig &AppConfig::instance()
+{
+    static AppConfig inst;
+    return inst;
+}
+
+AppConfig::AppConfig()
+{
+    load();
+}
+
+void AppConfig::load()
+{
+    QFile f(kConfigFile);
+    if (!f.open(QIODevice::ReadOnly))
+        return; // file doesn't exist yet — all values stay at defaults
+
+    const QJsonObject obj = QJsonDocument::fromJson(f.readAll()).object();
+    f.close();
+
+    m_autoConnect = obj.value(QStringLiteral("auto_connect")).toBool(false);
+}
+
+bool AppConfig::save() const
+{
+    QDir dir;
+    if (!dir.mkpath(kConfigDir))
+        return false;
+
+    QJsonObject obj;
+    obj[QStringLiteral("auto_connect")] = m_autoConnect;
+
+    QFile f(kConfigFile);
+    if (!f.open(QIODevice::WriteOnly | QIODevice::Text))
+        return false;
+
+    f.write(QJsonDocument(obj).toJson(QJsonDocument::Indented));
+    return true;
+}
+
+bool AppConfig::autoConnect() const { return m_autoConnect; }
+
+void AppConfig::setAutoConnect(bool value)
+{
+    if (m_autoConnect == value) return;
+    m_autoConnect = value;
+    save();
+}
+

--- a/src/appconfig.h
+++ b/src/appconfig.h
@@ -1,0 +1,32 @@
+#pragma once
+
+#include <QString>
+#include <QMap>
+
+// ---------------------------------------------------------------------------
+// AppConfig – persists app-level preferences to
+//   ~/.config/ProtonVPN-Qt/app.json
+//
+// Easy to relocate: change kConfigDir / kConfigFile below.
+// ---------------------------------------------------------------------------
+class AppConfig
+{
+public:
+    // Returns the shared instance (loaded on first access).
+    static AppConfig &instance();
+
+    // Getters
+    bool autoConnect() const;
+
+    // Setters – immediately persist to disk.
+    void setAutoConnect(bool value);
+
+private:
+    AppConfig();  // use instance()
+
+    void load();
+    bool save() const;
+
+    bool m_autoConnect = false;
+};
+

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -18,6 +18,7 @@
 #include "pages/countriespage.h"
 #include "pages/accountpage.h"
 #include "pages/settingspage.h"
+#include "appconfig.h"
 
 static QIcon svgNavIcon(const QString &path, const QSize &size = {24, 24}, bool tintInDarkMode = true)
 {
@@ -145,6 +146,9 @@ MainWindow::MainWindow(QWidget *parent)
             m_sidebar->setEnabled(true);
             showPage(Page::Vpn);
             m_manager->fetchCountries();
+            // Mark that we should auto-connect once the initial status check resolves.
+            if (AppConfig::instance().autoConnect())
+                m_startupAutoConnectPending = true;
         } else {
             m_sidebar->setEnabled(false);
             showPage(Page::Login);
@@ -181,6 +185,13 @@ MainWindow::MainWindow(QWidget *parent)
             [this](VpnState state, const QString &info) {
         m_vpnPage->onStateChanged(state, info);
         updateTrayIcon(state);
+
+        // Auto-connect: if we flagged a pending connect and we just confirmed
+        // the VPN is disconnected, initiate the connection now.
+        if (m_startupAutoConnectPending && state == VpnState::Disconnected) {
+            m_startupAutoConnectPending = false;
+            m_manager->connectVpn();
+        }
     });
 
     // System tray icon

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -55,6 +55,7 @@ private:
     void updateTrayIcon(VpnState state);
 
     QSystemTrayIcon *m_trayIcon;
-    QAction *m_trayConnectAction;
+    QAction         *m_trayConnectAction;
+    bool             m_startupAutoConnectPending = false; // fire auto-connect once on first Disconnected state
 };
 

--- a/src/pages/settingspage.cpp
+++ b/src/pages/settingspage.cpp
@@ -1,4 +1,5 @@
 #include "settingspage.h"
+#include "../appconfig.h"
 
 #include <QVBoxLayout>
 #include <QHBoxLayout>
@@ -12,8 +13,13 @@
 #include <QTextBrowser>
 #include <QMessageBox>
 #include <QFile>
+#include <QDir>
+#include <QStandardPaths>
+#include <QProcess>
+#include <QCoreApplication>
 #include <QJsonDocument>
 #include <QJsonObject>
+#include <QDebug>
 
 // ============================================================
 // ToggleSwitch
@@ -160,8 +166,134 @@ QWidget *SettingsPage::makeComboRow(QWidget *parent, const QString &label,
 }
 
 // ============================================================
+// Auto-start helpers (systemd user service)
+// ============================================================
+
+// Easy-to-change constant: directory where the .service file lives.
+static const QString kSystemdUserServiceDir =
+    QDir::homePath() + QStringLiteral("/.config/systemd/user");
+static const QString kServiceName = QStringLiteral("proton-vpn-qt.service");
+
+// In debug builds, skip actual systemd/file operations so the toggle can be
+// tested without installing a real service. Flip to false to test for real.
+#ifdef QT_DEBUG
+static constexpr bool kDryRun = true;
+#else
+static constexpr bool kDryRun = false;
+#endif
+
+QString SettingsPage::serviceFilePath()
+{
+    return kSystemdUserServiceDir + QLatin1Char('/') + kServiceName;
+}
+
+bool SettingsPage::systemdAvailable()
+{
+    // Check once whether systemctl is on PATH by trying to start it with --version.
+    static int cached = -1; // -1 = unchecked, 0 = absent, 1 = present
+    if (cached != -1) return cached == 1;
+
+    QProcess p;
+    p.start(QStringLiteral("systemctl"), {QStringLiteral("--version")});
+    cached = (p.waitForStarted(2000) && p.waitForFinished(2000)) ? 1 : 0;
+    return cached == 1;
+}
+
+bool SettingsPage::autoStartEnabled()
+{
+    if (kDryRun)             return false; // dry-run: always report disabled
+    if (!systemdAvailable()) return false;
+
+    // Ask systemd whether the service is enabled. Exit code 0 = enabled.
+    QProcess p;
+    p.start(QStringLiteral("systemctl"),
+            {QStringLiteral("--user"), QStringLiteral("is-enabled"), kServiceName});
+    if (!p.waitForFinished(3000)) return false;
+    const QString out = QString::fromUtf8(p.readAllStandardOutput()).trimmed().toLower();
+    return out == QStringLiteral("enabled") || out == QStringLiteral("static");
+}
+
+bool SettingsPage::setAutoStart(bool enable, QString &errorOut)
+{
+    if (kDryRun) {
+        qDebug("[DryRun] setAutoStart(%s) — skipping real systemd operations.",
+               enable ? "true" : "false");
+        return true; // pretend success
+    }
+
+    if (enable) {
+        // Resolve the path to the currently running executable.
+        const QString exe = QCoreApplication::applicationFilePath();
+
+        // Create the systemd user service directory if it doesn't exist.
+        QDir dir;
+        if (!dir.mkpath(kSystemdUserServiceDir)) {
+            errorOut = QStringLiteral("Could not create directory: ") + kSystemdUserServiceDir;
+            return false;
+        }
+
+        // Write the .service file.
+        const QString serviceContent =
+            QStringLiteral("[Unit]\n"
+                           "Description=ProtonVPN Qt App\n"
+                           "After=graphical-session.target\n"
+                           "PartOf=graphical-session.target\n"
+                           "\n"
+                           "[Service]\n"
+                           "Type=simple\n"
+                           "ExecStart=%1\n"
+                           "Restart=on-failure\n"
+                           "Environment=DISPLAY=:0\n"
+                           "\n"
+                           "[Install]\n"
+                           "WantedBy=graphical-session.target\n").arg(exe);
+
+        QFile f(serviceFilePath());
+        if (!f.open(QIODevice::WriteOnly | QIODevice::Text)) {
+            errorOut = QStringLiteral("Could not write service file: ") + serviceFilePath();
+            return false;
+        }
+        f.write(serviceContent.toUtf8());
+        f.close();
+
+        // Enable the service (creates the symlink so it starts automatically).
+        QProcess p;
+        p.start(QStringLiteral("systemctl"),
+                {QStringLiteral("--user"), QStringLiteral("enable"), kServiceName});
+        p.waitForFinished(5000);
+        if (p.exitCode() != 0) {
+            errorOut = QString::fromUtf8(p.readAllStandardError()).trimmed();
+            if (errorOut.isEmpty())
+                errorOut = QStringLiteral("systemctl --user enable failed (exit %1)").arg(p.exitCode());
+            return false;
+        }
+    } else {
+        // Disable and remove.
+        QProcess p;
+        p.start(QStringLiteral("systemctl"),
+                {QStringLiteral("--user"), QStringLiteral("disable"), kServiceName});
+        p.waitForFinished(5000);
+
+        QFile::remove(serviceFilePath());
+    }
+    return true;
+}
+
+// ============================================================
 // SettingsPage constructor
 // ============================================================
+
+void SettingsPage::updateAutoConnectRowVisibility()
+{
+    if (!m_autoConnectRow) return;
+    const bool show = m_autoStartToggle && m_autoStartToggle->isOn();
+    m_autoConnectRow->setVisible(show);
+    // If auto-start is turned off, also disable auto-connect and persist that.
+    if (!show && m_autoConnectToggle && m_autoConnectToggle->isOn()) {
+        m_autoConnectToggle->setOn(false, false);
+        AppConfig::instance().setAutoConnect(false);
+    }
+}
 
 SettingsPage::SettingsPage(VpnManager *manager, QWidget *parent)
     : QWidget(parent), m_manager(manager)
@@ -207,6 +339,54 @@ SettingsPage::SettingsPage(VpnManager *manager, QWidget *parent)
         first = false;
         cardLayout->addWidget(w);
     };
+
+    // ── Auto-start (systemd user service) ────────────────────
+    // Only show this row if systemd is available on this system.
+    if (systemdAvailable()) {
+        m_autoStartRow = new QWidget(card);
+        auto *rl = new QHBoxLayout(m_autoStartRow);
+        rl->setContentsMargins(16, 12, 16, 12);
+        rl->addLayout(makeTextCol(m_autoStartRow,
+            QStringLiteral("Launch on Startup"),
+            QStringLiteral("Automatically start the app in the background when you log in "
+                           "(installs a systemd user service).")));
+        rl->addStretch();
+        m_autoStartToggle = new ToggleSwitch(m_autoStartRow);
+        m_autoStartToggle->setOn(autoStartEnabled(), false);
+        connect(m_autoStartToggle, &ToggleSwitch::toggled, this, [this](bool on) {
+            QString err;
+            if (!setAutoStart(on, err)) {
+                m_autoStartToggle->setOn(!on, false);
+                QMessageBox::warning(this,
+                    QStringLiteral("Auto-start Error"),
+                    QStringLiteral("Failed to %1 auto-start:\n%2")
+                        .arg(on ? QStringLiteral("enable") : QStringLiteral("disable"), err));
+            } else {
+                updateAutoConnectRowVisibility();
+            }
+        });
+        rl->addWidget(m_autoStartToggle);
+        add(m_autoStartRow);
+
+        // ── Auto-connect on startup ───────────────────────────
+        // Shown indented beneath auto-start, only when auto-start is on.
+        m_autoConnectRow = new QWidget(card);
+        auto *acRl = new QHBoxLayout(m_autoConnectRow);
+        acRl->setContentsMargins(32, 8, 16, 12); // extra left indent
+        acRl->addLayout(makeTextCol(m_autoConnectRow,
+            QStringLiteral("Auto-connect on Startup"),
+            QStringLiteral("Automatically connect to the VPN when the app starts.")));
+        acRl->addStretch();
+        m_autoConnectToggle = new ToggleSwitch(m_autoConnectRow);
+        m_autoConnectToggle->setOn(AppConfig::instance().autoConnect(), false);
+        connect(m_autoConnectToggle, &ToggleSwitch::toggled, this, [](bool on) {
+            AppConfig::instance().setAutoConnect(on);
+        });
+        acRl->addWidget(m_autoConnectToggle);
+        cardLayout->addWidget(m_autoConnectRow); // added directly, not via add() — shares divider with autostart
+
+        updateAutoConnectRowVisibility();
+    }
 
     // ── Anonymous Crash Reports (on/off) ──────────────────────
     add(makeToggleRow(card,
@@ -364,8 +544,9 @@ void SettingsPage::setLoading(bool loading)
     }
     for (const auto &r : std::as_const(m_toggleRows)) r.toggle->setEnabled(!loading);
     for (const auto &r : std::as_const(m_comboRows))  r.combo->setEnabled(!loading);
-    if (m_dnsToggle)   m_dnsToggle->setEnabled(!loading);
-    if (m_dnsApplyBtn) m_dnsApplyBtn->setEnabled(!loading);
+    if (m_autoStartToggle) m_autoStartToggle->setEnabled(!loading);
+    if (m_dnsToggle)       m_dnsToggle->setEnabled(!loading);
+    if (m_dnsApplyBtn)     m_dnsApplyBtn->setEnabled(!loading);
 }
 
 void SettingsPage::onSettingsReady(const QMap<QString, QString> &info)

--- a/src/pages/settingspage.h
+++ b/src/pages/settingspage.h
@@ -71,9 +71,17 @@ private:
     QList<ComboRow>    m_comboRows;
 
     // Custom DNS widgets
-    ToggleSwitch      *m_dnsToggle    = nullptr;
-    QLineEdit         *m_dnsEdit      = nullptr;
-    QPushButton       *m_dnsApplyBtn  = nullptr;
+    ToggleSwitch      *m_dnsToggle      = nullptr;
+    QLineEdit         *m_dnsEdit        = nullptr;
+    QPushButton       *m_dnsApplyBtn    = nullptr;
+
+    // Auto-start (systemd user service)
+    ToggleSwitch      *m_autoStartToggle  = nullptr;
+    QWidget           *m_autoStartRow     = nullptr;
+
+    // Auto-connect on startup (shown only when auto-start is on)
+    ToggleSwitch      *m_autoConnectToggle = nullptr;
+    QWidget           *m_autoConnectRow    = nullptr;
 
     QPushButton       *m_refreshBtn;
     QLabel            *m_statusLabel;
@@ -89,6 +97,13 @@ private:
                           const QStringList &cliValues, bool needsReconnect);
     void addDivider(QVBoxLayout *layout, QWidget *parent);
     void maybeWarnReconnect(bool needsReconnect);
+
+    // Auto-start helpers
+    static QString serviceFilePath();
+    static bool    systemdAvailable();
+    static bool    autoStartEnabled();
+    static bool    setAutoStart(bool enable, QString &errorOut);
+    void           updateAutoConnectRowVisibility();
 
     void onSettingsReady(const QMap<QString, QString> &settings);
     void showAboutDialog();

--- a/src/version.json
+++ b/src/version.json
@@ -1,5 +1,5 @@
 {
-    "app_version": "1.0.0",
+    "app_version": "1.1.0",
     "cli_version_tested": "0.1.6"
 }
 


### PR DESCRIPTION
Introduce AppConfig to persist app preferences (~/.config/ProtonVPN-Qt/app.json) and wire it into the UI and startup flow. Add a systemd user service installer in Settings (toggle to enable/disable auto-start) with a nested Auto-connect-on-startup toggle that persists via AppConfig; debug builds run in dry-run mode. MainWindow now reads the stored auto-connect flag and triggers a connect after the initial status check if requested. Added appconfig.h/cpp, updated CMakeLists, adjusted settings and main window code, and bumped app version to 1.1.0.