### PR TITLE
Works with CLI 1.0.0. Add Start Hidden setting and kill-switch changes

### DIFF
--- a/src/appconfig.cpp
+++ b/src/appconfig.cpp
@@ -33,6 +33,7 @@ void AppConfig::load()
     m_autoConnect = obj.value(QStringLiteral("auto_connect")).toBool(false);
     m_notifications = obj.value(QStringLiteral("notifications")).toBool(true);
     m_recentConnectionsCount = obj.value(QStringLiteral("recent_connections_count")).toInt(5);
+    m_startHidden = obj.value(QStringLiteral("start_hidden")).toBool(false);
 }
 
 bool AppConfig::save() const
@@ -45,6 +46,7 @@ bool AppConfig::save() const
     obj[QStringLiteral("auto_connect")] = m_autoConnect;
     obj[QStringLiteral("notifications")] = m_notifications;
     obj[QStringLiteral("recent_connections_count")] = m_recentConnectionsCount;
+    obj[QStringLiteral("start_hidden")] = m_startHidden;
 
     QFile f(kConfigFile);
     if (!f.open(QIODevice::WriteOnly | QIODevice::Text))
@@ -78,6 +80,15 @@ void AppConfig::setRecentConnectionsCount(const int value)
 {
     if (m_recentConnectionsCount == value) return;
     m_recentConnectionsCount = qMax(0, value);
+    save();
+}
+
+bool AppConfig::startHidden() const { return m_startHidden; }
+
+void AppConfig::setStartHidden(const bool value)
+{
+    if (m_startHidden == value) return;
+    m_startHidden = value;
     save();
 }
 

--- a/src/appconfig.h
+++ b/src/appconfig.h
@@ -15,10 +15,12 @@ public:
     bool autoConnect() const;
     bool notifications() const;
     int  recentConnectionsCount() const;
+    bool startHidden() const;
 
     void setAutoConnect(bool value);
     void setNotifications(bool value);
     void setRecentConnectionsCount(int value);
+    void setStartHidden(bool value);
 
 private:
     AppConfig();
@@ -28,5 +30,6 @@ private:
     bool m_autoConnect    = false;
     bool m_notifications  = true;
     int  m_recentConnectionsCount = 5;
+    bool m_startHidden = false;
 };
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -8,6 +8,7 @@
 #include <QJsonDocument> // Ignore unused include warning; we do use QJsonDocument
 #include <QJsonObject>
 #include "mainwindow.h"
+#include "appconfig.h"
 
 int main(int argc, char* argv[])
 {
@@ -88,7 +89,10 @@ int main(int argc, char* argv[])
         app.setStyleSheet(QString::fromUtf8(qssFile.readAll()));
 
     MainWindow w;
-    w.show();
+    if (AppConfig::instance().startHidden())
+        w.hide();
+    else
+        w.show();
     return QApplication::exec();
 }
 

--- a/src/pages/settingspage.cpp
+++ b/src/pages/settingspage.cpp
@@ -179,7 +179,8 @@ void SettingsPage::maybeWarnReconnect(const QString& cliOutput)
 }
 
 QWidget* SettingsPage::makeToggleRow(QWidget* parent, const QString& label,
-                                     const QString& desc, const QString& cliKey)
+                                     const QString& desc, const QString& cliKey,
+                                     const QString& onValue)
 {
     auto* row = new QWidget(parent);
     auto* rl = new QHBoxLayout(row);
@@ -189,13 +190,13 @@ QWidget* SettingsPage::makeToggleRow(QWidget* parent, const QString& label,
     auto* toggle = new ToggleSwitch(row);
     rl->addWidget(toggle, 0);
 
-    connect(toggle, &ToggleSwitch::toggled, this, [this, cliKey](bool on)
+    connect(toggle, &ToggleSwitch::toggled, this, [this, cliKey, onValue](bool on)
     {
-        m_manager->applyConfigValue(cliKey, on ? QStringLiteral("on") : QStringLiteral("off"));
+        m_manager->applyConfigValue(cliKey, on ? onValue : QStringLiteral("off"));
         // Reconnect detection is handled via the configApplied signal.
     });
 
-    m_toggleRows.append({cliKey, toggle});
+    m_toggleRows.append({cliKey, toggle, onValue});
     return row;
 }
 
@@ -483,6 +484,26 @@ SettingsPage::SettingsPage(VpnManager* manager, QWidget* parent)
         addApp(row);
     }
 
+    // ── Start Hidden ───────────────────────────────────────────
+    {
+        auto* row = new QWidget(appCard);
+        auto* rl = new QHBoxLayout(row);
+        rl->setContentsMargins(16, 12, 16, 12);
+        rl->setSpacing(16);
+        rl->addWidget(makeTextCol(row,
+                                  QStringLiteral("Start Hidden"),
+                                  QStringLiteral("Launch the app in the background without opening a "
+                                      "window. Access it anytime via the system tray icon.")), 1);
+        auto* toggle = new ToggleSwitch(row);
+        toggle->setOn(AppConfig::instance().startHidden(), false);
+        connect(toggle, &ToggleSwitch::toggled, this, [](bool on)
+        {
+            AppConfig::instance().setStartHidden(on);
+        });
+        rl->addWidget(toggle);
+        addApp(row);
+    }
+
     // ── Plus Members Only divider (App tab) ───────────────────
     m_appPlusDivider = makePlusDivider(appCard);
     appCardLayout->addWidget(m_appPlusDivider);
@@ -627,14 +648,12 @@ SettingsPage::SettingsPage(VpnManager* manager, QWidget* parent)
                          QStringLiteral("ipv6")));
 
     // ── Kill Switch ───────────────────────────────────────────
-    addVpn(makeComboRow(vpnCard,
-                        QStringLiteral("Kill Switch"),
-                        QStringLiteral("Block traffic if the VPN connection drops. "
-                            "\"Standard\" only blocks while reconnecting; "
-                            "\"Permanent\" blocks even when the VPN is off."),
-                        QStringLiteral("kill-switch"),
-                        {QStringLiteral("Off"), QStringLiteral("Standard"), QStringLiteral("Permanent")},
-                        {QStringLiteral("off"), QStringLiteral("standard"), QStringLiteral("full")}));
+    addVpn(makeToggleRow(vpnCard,
+                         QStringLiteral("Kill Switch"),
+                         QStringLiteral("Block internet access if the VPN connection drops unexpectedly. "
+                             "Internet is only blocked while the VPN is active and reconnecting."),
+                         QStringLiteral("kill-switch"),
+                         QStringLiteral("standard")));
 
     // ── Plus Members Only divider ─────────────────────────────
     m_plusDivider = makePlusDivider(vpnCard);
@@ -844,9 +863,14 @@ void SettingsPage::onSettingsReady(const QMap<QString, QString>& info)
         return info.value(key).toLower().trimmed();
     };
 
-    // Toggle rows
+    // Toggle rows – a row is ON if the value matches the row's onValue OR
+    // one of the generic truthy strings (for standard "on"/"true" settings).
     for (const auto& row : std::as_const(m_toggleRows))
-        row.toggle->setOn(isOnString(val(row.cliKey)), false);
+    {
+        const QString v = val(row.cliKey);
+        const bool on = (v == row.onValue) || isOnString(v);
+        row.toggle->setOn(on, false);
+    }
 
     // Combo rows – find the matching CLI value and select that index
     for (const auto& row : std::as_const(m_comboRows))

--- a/src/pages/settingspage.h
+++ b/src/pages/settingspage.h
@@ -65,6 +65,9 @@ private:
     {
         QString cliKey;
         ToggleSwitch* toggle = nullptr;
+        // Value sent to the CLI (and expected when loading) for the ON state.
+        // Most settings use "on"; kill-switch uses "standard".
+        QString onValue = QStringLiteral("on");
     };
 
     // A combo-box row (multi-value setting)
@@ -120,7 +123,8 @@ private:
 
     // Helpers
     QWidget* makeToggleRow(QWidget* parent, const QString& label, const QString& desc,
-                           const QString& cliKey);
+                           const QString& cliKey,
+                           const QString& onValue = QStringLiteral("on"));
     QWidget* makeComboRow(QWidget* parent, const QString& label, const QString& desc,
                           const QString& cliKey, const QStringList& labels,
                           const QStringList& cliValues);

--- a/src/version.json
+++ b/src/version.json
@@ -1,6 +1,6 @@
 {
-    "app_version": "1.6.2",
-    "prerelease": false,
-    "cli_version_tested": "0.1.9"
+    "app_version": "1.7.0-rc.1",
+    "prerelease": true,
+    "cli_version_tested": "1.0.0"
 }
 

--- a/src/vpnmanager.cpp
+++ b/src/vpnmanager.cpp
@@ -533,21 +533,12 @@ void VpnManager::fetchSettings()
     };
 
     // ── top-level keys ────────────────────────────────────────────────────
-    // killswitch: 0 = off, 1 = standard, 2 = permanent/full
+    // killswitch: 0 = off, 1 = standard
     if (root.contains(QStringLiteral("killswitch")))
     {
         const int ks = root[QStringLiteral("killswitch")].toInt(0);
-        QString ksVal;
-        switch (ks)
-        {
-        case 1: ksVal = QStringLiteral("standard");
-            break;
-        case 2: ksVal = QStringLiteral("full");
-            break;
-        default: ksVal = QStringLiteral("off");
-            break;
-        }
-        settings.insert(QStringLiteral("kill-switch"), ksVal);
+        settings.insert(QStringLiteral("kill-switch"),
+                        ks == 1 ? QStringLiteral("standard") : QStringLiteral("off"));
     }
 
     if (root.contains(QStringLiteral("ipv6")))


### PR DESCRIPTION
- Add a new AppConfig option 'startHidden' (load/save/accessors) and honor it in main to optionally start the app hidden.

- Expose a SettingsPage toggle for Start Hidden.

- Replace the Kill Switch combo with a toggle (onValue 'standard') and simplify VpnManager parsing to map killswitch=1 to 'standard' and other values to 'off'.

- Bump app version to 1.7.0-rc.1 (prerelease) and update tested CLI version to 1.0.0.