### PR TITLE
Enhance NAT-PMP support and update reconnect button label

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,20 @@ A Qt GUI front-end for the [Proton VPN Linux CLI](https://protonvpn.com/support/
 - Anonymous Crash Reports, IPv6, Kill Switch — available on all plans
 - *(Plus)* NAT Type, VPN Accelerator, NetShield Ad-blocker, Port Forwarding, Custom DNS
 
+### Port Forwarding *(Plus)*
+
+When Port Forwarding is enabled in Settings and you are connected to a P2P server, the app automatically manages the NAT-PMP lease using `natpmpc`:
+
+- The **forwarded port number** is displayed on the main VPN page with a one-click **Copy** button for easy use with torrent clients (e.g. Transmission, qBittorrent)
+- A **keep-alive loop** runs every 45 seconds to renew the 60-second NAT-PMP lease — the port stays valid as long as the app is open
+- If the app is closed while port forwarding is active, the lease will lapse within 60 seconds. A warning is shown in the quit dialog when this applies
+- If `natpmpc` is not installed, a banner is shown when you connect to a P2P server with port forwarding enabled. Install it with:
+  - **Debian / Ubuntu:** `sudo apt install natpmpc`
+  - **Fedora:** `sudo dnf install libnatpmp`
+  - **Arch:** `sudo pacman -S libnatpmp`
+
+`natpmpc` is an **optional** dependency — users who do not use port forwarding are unaffected by its absence.
+
 ---
 
 ## Screenshots
@@ -67,6 +81,9 @@ A Qt GUI front-end for the [Proton VPN Linux CLI](https://protonvpn.com/support/
 | `systemd` (user session) | **Optional** — required for the "Launch on Startup" feature |
 
 The app communicates exclusively with the `protonvpn` CLI. `curl` degrades gracefully if absent.
+
+> [!WARNING]
+> **The official Proton VPN GTK app is not supported alongside this app and will cause problems.** Both apps will conflict over connection state and session management. The CLI will produce errors when two front-ends are running at the same time. If you have the GTK app installed, it is advised that you uninstall it before using this app.
 
 ---
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -27,6 +27,9 @@ set(SOURCES
         uihelpers.h
         vpnmanager.h
         vpnmanager.cpp
+        cli/protonvpncli.cpp
+        cli/natpmpmanager.h
+        cli/natpmpmanager.cpp
         mainwindow.h
         mainwindow.cpp
         widgets/elidalabel.h

--- a/src/cli/natpmpmanager.cpp
+++ b/src/cli/natpmpmanager.cpp
@@ -1,0 +1,93 @@
+// natpmpmanager.cpp
+// NatPmpManager: NAT-PMP port-forwarding keep-alive loop.
+// All UI concerns live in the consumer (VpnPage); this class only manages
+// the process lifecycle and emits result signals.
+
+#include "natpmpmanager.h"
+
+#include <QProcess>
+#include <QRegularExpression>
+#include <QStandardPaths>
+#include <QTimer>
+
+NatPmpManager::NatPmpManager(QObject* parent)
+    : QObject(parent)
+{
+}
+
+void NatPmpManager::start()
+{
+    if (m_timer)
+        return; // already running
+
+    if (QStandardPaths::findExecutable(QStringLiteral("natpmpc")).isEmpty())
+    {
+        emit natpmpcMissing();
+        return;
+    }
+
+    m_timer = new QTimer(this);
+    m_timer->setInterval(45'000); // 45 s keeps a 60 s NAT-PMP lease alive
+    connect(m_timer, &QTimer::timeout, this, &NatPmpManager::run);
+    m_timer->start();
+
+    run(); // fire immediately so the port appears without a 45 s wait
+}
+
+void NatPmpManager::stop()
+{
+    if (m_timer)
+    {
+        m_timer->stop();
+        m_timer->deleteLater();
+        m_timer = nullptr;
+    }
+    m_active        = false;
+    m_forwardedPort = 0;
+}
+
+void NatPmpManager::run()
+{
+    if (m_active)
+        return; // previous invocation still in flight
+
+    m_active = true;
+
+    auto* process = new QProcess(this);
+    connect(process, QOverload<int, QProcess::ExitStatus>::of(&QProcess::finished),
+            this, [this, process](int exitCode, QProcess::ExitStatus)
+    {
+        m_active = false;
+        const QString out = QString::fromUtf8(process->readAllStandardOutput())
+                          + QString::fromUtf8(process->readAllStandardError());
+        process->deleteLater();
+
+        if (exitCode != 0)
+        {
+            if (m_forwardedPort != 0)
+            {
+                m_forwardedPort = 0;
+                emit portLost();
+            }
+            return;
+        }
+
+        // Example output: "Mapped public port 53186 protocol UDP lifetime 60"
+        const QRegularExpression re(QStringLiteral(R"(Mapped public port (\d+))"));
+        const QRegularExpressionMatch match = re.match(out);
+        if (match.hasMatch())
+        {
+            m_forwardedPort = match.captured(1).toInt();
+            emit portAcquired(m_forwardedPort);
+        }
+    });
+
+    // Both UDP and TCP mappings are required by the ProtonVPN port-forwarding
+    // spec; the allocated port number is the same for both and is parsed from
+    // the UDP response.
+    process->start(QStringLiteral("/bin/sh"),
+                   {QStringLiteral("-c"),
+                    QStringLiteral("natpmpc -a 1 0 udp 60 -g 10.2.0.1 "
+                                   "&& natpmpc -a 1 0 tcp 60 -g 10.2.0.1")});
+}
+

--- a/src/cli/natpmpmanager.h
+++ b/src/cli/natpmpmanager.h
@@ -1,0 +1,52 @@
+#pragma once
+
+#include <QObject>
+
+class QTimer;
+
+// ---------------------------------------------------------------------------
+// NatPmpManager
+//
+// Manages the natpmpc keep-alive loop required by ProtonVPN port forwarding.
+// Runs `natpmpc -a 1 0 udp 60 -g 10.2.0.1 && natpmpc -a 1 0 tcp 60 -g 10.2.0.1`
+// every 45 seconds to maintain the 60-second NAT-PMP lease.
+//
+// Consumers connect to the signals and call start()/stop() as the VPN state
+// changes.  All UI concerns are left to the consumer.
+// ---------------------------------------------------------------------------
+class NatPmpManager : public QObject
+{
+    Q_OBJECT
+
+public:
+    explicit NatPmpManager(QObject* parent = nullptr);
+
+    // Start the keep-alive loop.
+    // Emits natpmpcMissing() immediately and returns without starting if the
+    // natpmpc binary is not found on PATH.
+    void start();
+
+    // Stop the loop and reset internal state.
+    void stop();
+
+    bool isRunning()     const { return m_timer != nullptr; }
+    int  forwardedPort() const { return m_forwardedPort; }
+
+signals:
+    // Emitted each time the port lease is successfully renewed.
+    void portAcquired(int port);
+
+    // Emitted when natpmpc exits non-zero — the port is no longer valid.
+    void portLost();
+
+    // Emitted from start() when natpmpc is not installed.
+    void natpmpcMissing();
+
+private:
+    void run(); // single natpmpc invocation
+
+    QTimer* m_timer         = nullptr;
+    bool    m_active        = false;  // true while a process is in flight
+    int     m_forwardedPort = 0;
+};
+

--- a/src/cli/protonvpncli.cpp
+++ b/src/cli/protonvpncli.cpp
@@ -1,0 +1,682 @@
+// protonvpncli.cpp
+// All VpnManager methods that interact with the protonvpn CLI by spawning
+// a QProcess.  State management, settings, and polling infrastructure live
+// in vpnmanager.cpp.
+
+#include "../vpnmanager.h"
+
+#include <QProcess>
+#include <QRegularExpression>
+#include <functional>
+#include <ranges>
+
+// ---------------------------------------------------------------------------
+// Internal helper — run any protonvpn sub-command asynchronously.
+// ---------------------------------------------------------------------------
+
+void VpnManager::runCommand(const QStringList& args,
+                            std::function<void(int, const QString&, const QString&)> callback)
+{
+    auto* process = new QProcess(this);
+    connect(process, QOverload<int, QProcess::ExitStatus>::of(&QProcess::finished),
+            this, [process, callback](int exitCode, QProcess::ExitStatus)
+            {
+                const QString out = QString::fromUtf8(process->readAllStandardOutput()).trimmed();
+                const QString err = QString::fromUtf8(process->readAllStandardError()).trimmed();
+                callback(exitCode, out, err);
+                process->deleteLater();
+            });
+    process->start(QStringLiteral("protonvpn"), args);
+}
+
+// ---------------------------------------------------------------------------
+// Installation / login
+// ---------------------------------------------------------------------------
+
+void VpnManager::checkInstalled()
+{
+    auto* process = new QProcess(this);
+    connect(process, QOverload<int, QProcess::ExitStatus>::of(&QProcess::finished),
+            this, [this, process](int exitCode, QProcess::ExitStatus)
+            {
+                Q_UNUSED(exitCode)
+                QString out = QString::fromUtf8(process->readAllStandardOutput());
+                QString err = QString::fromUtf8(process->readAllStandardError());
+                bool installed = !out.isEmpty() || !err.isEmpty();
+                process->deleteLater();
+                emit installedResult(installed);
+            });
+    process->start(QStringLiteral("protonvpn"), QStringList{QStringLiteral("--help")});
+    if (!process->waitForStarted(2000))
+    {
+        process->deleteLater();
+        emit installedResult(false);
+    }
+}
+
+void VpnManager::checkLoginStatus()
+{
+    runCommand({QStringLiteral("info")}, [this](int, const QString& out, const QString&)
+    {
+        bool loggedIn = false;
+        QString username;
+
+        const QRegularExpression re(QStringLiteral(R"(Account:\s*'([^']+)')"));
+        const auto match = re.match(out);
+        if (match.hasMatch())
+        {
+            const QString accountVal = match.captured(1).trimmed();
+            if (accountVal != QStringLiteral("None") && !accountVal.isEmpty())
+            {
+                loggedIn = true;
+                username = accountVal;
+            }
+        }
+
+        if (loggedIn)
+        {
+            checkConnectionStatus();
+            startPolling();
+            fetchAccountType();
+        }
+
+        emit loginStatusResult(loggedIn, username);
+    });
+}
+
+void VpnManager::login(const QString& username, const QString& password)
+{
+    // CLI flow: protonvpn signin <username>
+    //   stderr: "Password: "   → write password + '\n' to stdin
+    //   stderr: "2FA Token: "  → optional; emit twoFactorRequired()
+
+    if (m_signinProcess)
+    {
+        m_signinProcess->kill();
+        m_signinProcess->deleteLater();
+        m_signinProcess = nullptr;
+    }
+
+    m_signinProcess = new QProcess(this);
+    QProcess* process = m_signinProcess;
+
+    struct State
+    {
+        QString accumulated;
+        bool passwordSent = false;
+        bool twoFAEmitted = false;
+    };
+    auto* state = new State();
+
+    auto processOutput = [this, process, state, password]()
+    {
+        if (!state->passwordSent &&
+            state->accumulated.contains(QStringLiteral("Password:")))
+        {
+            state->passwordSent = true;
+            process->write((password + QLatin1Char('\n')).toUtf8());
+        }
+
+        if (!state->twoFAEmitted &&
+            state->accumulated.contains(QStringLiteral("2FA Token:")))
+        {
+            state->twoFAEmitted = true;
+            emit twoFactorRequired();
+        }
+    };
+
+    connect(process, &QProcess::readyReadStandardOutput, this,
+            [process, state, processOutput]()
+            {
+                state->accumulated.append(QString::fromUtf8(process->readAllStandardOutput()));
+                processOutput();
+            });
+
+    connect(process, &QProcess::readyReadStandardError, this,
+            [process, state, processOutput]()
+            {
+                state->accumulated.append(QString::fromUtf8(process->readAllStandardError()));
+                processOutput();
+            });
+
+    connect(process, QOverload<int, QProcess::ExitStatus>::of(&QProcess::finished),
+            this, [this, process, state](const int exitCode, QProcess::ExitStatus)
+            {
+                const QString combined = state->accumulated.trimmed();
+                delete state;
+
+                if (process == m_signinProcess)
+                    m_signinProcess = nullptr;
+                process->deleteLater();
+
+                const bool ok = exitCode == 0;
+                QString errorMsg;
+                if (!ok)
+                {
+                    const QStringList lines = combined.split(QLatin1Char('\n'), Qt::SkipEmptyParts);
+                    for (const auto& line : std::ranges::reverse_view(lines))
+                    {
+                        const QString l = line.trimmed();
+                        if (!l.isEmpty()
+                            && !l.startsWith(QStringLiteral("Password:"))
+                            && !l.startsWith(QStringLiteral("2FA")))
+                        {
+                            errorMsg = l;
+                            break;
+                        }
+                    }
+                    if (errorMsg.isEmpty()) errorMsg = combined;
+                }
+                else
+                {
+                    checkConnectionStatus();
+                    startPolling();
+                    fetchAccountType();
+                }
+                emit loginFinished(ok, errorMsg);
+            });
+
+    process->start(QStringLiteral("protonvpn"),
+                   QStringList{QStringLiteral("signin"), username});
+}
+
+void VpnManager::submit2FA(const QString& token) const
+{
+    if (m_signinProcess && m_signinProcess->state() == QProcess::Running)
+        m_signinProcess->write((token + QStringLiteral("\n")).toUtf8());
+}
+
+void VpnManager::signOut()
+{
+    stopPolling();
+    runCommand({QStringLiteral("signout")}, [this](int exitCode, const QString&, const QString&)
+    {
+        m_state = VpnState::Disconnected;
+        emit signOutFinished(exitCode == 0);
+    });
+}
+
+// ---------------------------------------------------------------------------
+// Connection management
+// ---------------------------------------------------------------------------
+
+void VpnManager::connectVpn(const QString& country, const QString& city)
+{
+    m_lastConnectCountry = country;
+    m_lastConnectCity    = city;
+    m_connectedServer.clear();
+
+    m_state = VpnState::Connecting;
+    emit connectionStateChanged(m_state, QString());
+
+    QStringList args{QStringLiteral("connect")};
+    if (!country.isEmpty())
+        args << QStringLiteral("--country") << country;
+    if (!city.isEmpty())
+        args << QStringLiteral("--city") << city;
+
+    runCommand(args, [this](int exitCode, const QString& out, const QString& err)
+    {
+        if (exitCode == 0)
+        {
+            m_state = VpnState::Connected;
+            // Strip noise / port-forwarding guide lines from CLI output.
+            QStringList lines = out.split(QLatin1Char('\n'));
+            lines.erase(std::ranges::remove_if(lines, [](const QString& l)
+            {
+                const QString ll = l.toLower();
+                return ll.contains(QLatin1String("outdated")) ||
+                    ll.contains(QLatin1String("updating")) ||
+                    ll.contains(QLatin1String("this may take")) ||
+                    ll.contains(QLatin1String("to get your forwarded port")) ||
+                    ll.contains(QLatin1String("natpmpc")) ||
+                    (ll.startsWith(QLatin1String("guide:")) && ll.contains(QLatin1String("http")));
+            }).begin(), lines.end());
+            while (!lines.isEmpty() && lines.first().trimmed().isEmpty())
+                lines.removeFirst();
+            emit connectionStateChanged(m_state, lines.join(QLatin1Char('\n')));
+        }
+        else
+        {
+            m_state = VpnState::Error;
+            emit connectionStateChanged(m_state, err.isEmpty() ? out : err);
+            emit errorOccurred(err.isEmpty() ? out : err);
+        }
+    });
+}
+
+void VpnManager::disconnectVpn()
+{
+    m_state = VpnState::Disconnecting;
+    emit connectionStateChanged(m_state, QString());
+
+    runCommand({QStringLiteral("disconnect")}, [this](const int exitCode, const QString& out, const QString& err)
+    {
+        if (exitCode == 0)
+        {
+            m_state = VpnState::Disconnected;
+            emit connectionStateChanged(m_state, out);
+        }
+        else
+        {
+            m_state = VpnState::Error;
+            emit connectionStateChanged(m_state, err.isEmpty() ? out : err);
+            emit errorOccurred(err.isEmpty() ? out : err);
+        }
+    });
+}
+
+void VpnManager::disconnectVpnSync()
+{
+    // Used at application exit — run synchronously so the event loop does not
+    // need to stay alive.
+    QProcess process;
+    process.start(QStringLiteral("protonvpn"), QStringList{QStringLiteral("disconnect")});
+    process.waitForFinished(10000); // up to 10 s
+}
+
+void VpnManager::applyConfigValueAndReconnect(const QString& key, const QString& value)
+{
+    const QString country = m_lastConnectCountry;
+    const QString city    = m_lastConnectCity;
+
+    m_state = VpnState::Disconnecting;
+    emit connectionStateChanged(m_state, QString());
+
+    runCommand({QStringLiteral("disconnect")},
+               [this, key, value, country, city](int exitCode, const QString&, const QString& err)
+    {
+        if (exitCode != 0)
+        {
+            m_state = VpnState::Error;
+            emit connectionStateChanged(m_state, err);
+            emit errorOccurred(err);
+            return;
+        }
+
+        m_state = VpnState::Disconnected;
+        emit connectionStateChanged(m_state, QString());
+
+        QStringList args{QStringLiteral("config"), QStringLiteral("set")};
+        args << key;
+        args << value.split(QLatin1Char(' '), Qt::SkipEmptyParts);
+
+        runCommand(args, [this, country, city](int, const QString& out, const QString& err2)
+        {
+            emit configApplied((out + QLatin1Char('\n') + err2).trimmed());
+            connectVpn(country, city);
+        });
+    });
+}
+
+// ---------------------------------------------------------------------------
+// Server / city / account queries
+// ---------------------------------------------------------------------------
+
+void VpnManager::fetchCountries()
+{
+    runCommand({QStringLiteral("countries"), QStringLiteral("list")},
+               [this](int, const QString& out, const QString& err)
+    {
+        const QString combined = out + QLatin1Char('\n') + err;
+        QMap<QString, QString> countries;
+        const QStringList lines = combined.split(QLatin1Char('\n'));
+        // Output format: separator line starting with "--", then "Name   Code" rows.
+        bool pastSeparator = false;
+        for (const QString& line : lines)
+        {
+            const QString trimmed = line.trimmed();
+            if (trimmed.isEmpty()) continue;
+            if (trimmed.startsWith(QStringLiteral("--"))) { pastSeparator = true; continue; }
+            if (!pastSeparator) continue;
+            const QStringList parts = line.split(QStringLiteral("  "), Qt::SkipEmptyParts);
+            if (parts.size() < 2) continue;
+            const QString name = parts.first().trimmed();
+            const QString code = parts.last().trimmed();
+            if (!name.isEmpty() && !code.isEmpty())
+                countries.insert(name, code);
+        }
+        emit countriesReady(countries);
+    });
+}
+
+void VpnManager::fetchCities(const QString& countryCode)
+{
+    runCommand({QStringLiteral("cities"), QStringLiteral("list"), countryCode},
+               [this, countryCode](int, const QString& out, const QString& err)
+               {
+                   const QString combined = out + QLatin1Char('\n') + err;
+                   QList<QPair<QString, QString>> cities;
+                   const QStringList lines = combined.split(QLatin1Char('\n'));
+                   // Output format: separator line, then "City   Features" rows.
+                   bool pastSeparator = false;
+                   for (const QString& line : lines)
+                   {
+                       const QString trimmed = line.trimmed();
+                       if (trimmed.isEmpty()) continue;
+                       if (trimmed.startsWith(QStringLiteral("--"))) { pastSeparator = true; continue; }
+                       if (!pastSeparator) continue;
+                       const QStringList parts = line.split(QStringLiteral("  "), Qt::SkipEmptyParts);
+                       const QString city     = parts.value(0).trimmed();
+                       const QString features = parts.value(1).trimmed();
+                       if (!city.isEmpty())
+                           cities.append({city, features});
+                   }
+                   emit citiesReady(countryCode, cities);
+               });
+}
+
+void VpnManager::fetchCityFeatures(const QString& countryCode, const QString& city,
+                                    std::function<void(const QString& features)> callback)
+{
+    runCommand({QStringLiteral("cities"), QStringLiteral("list"), countryCode},
+               [city, callback](int, const QString& out, const QString& err)
+               {
+                   const QString combined = out + QLatin1Char('\n') + err;
+                   const QStringList lines = combined.split(QLatin1Char('\n'));
+                   bool pastSeparator = false;
+                   for (const QString& line : lines)
+                   {
+                       const QString trimmed = line.trimmed();
+                       if (trimmed.isEmpty()) continue;
+                       if (trimmed.startsWith(QStringLiteral("--"))) { pastSeparator = true; continue; }
+                       if (!pastSeparator) continue;
+                       const QStringList parts = line.split(QStringLiteral("  "), Qt::SkipEmptyParts);
+                       const QString cityName = parts.value(0).trimmed();
+                       if (cityName.compare(city, Qt::CaseInsensitive) == 0)
+                       {
+                           callback(parts.value(1).trimmed());
+                           return;
+                       }
+                   }
+                   callback(QString()); // city not found
+               });
+}
+
+void VpnManager::fetchInfo()
+{
+    runCommand({QStringLiteral("info")}, [this](int, const QString& out, const QString&)
+    {
+        QMap<QString, QString> result;
+        const QRegularExpression re(QStringLiteral(R"((\w[\w ]*):\s*'([^']*)')"));
+        QRegularExpressionMatchIterator it = re.globalMatch(out);
+        while (it.hasNext())
+        {
+            const auto m = it.next();
+            result.insert(m.captured(1).trimmed(), m.captured(2).trimmed());
+        }
+        emit infoReady(result);
+    });
+}
+
+void VpnManager::fetchAccountType()
+{
+    runCommand({QStringLiteral("config"), QStringLiteral("list")},
+               [this](int, const QString& out, const QString& err)
+    {
+        const QString combined = out + QLatin1Char('\n') + err;
+        const AccountType type =
+            combined.contains(QStringLiteral("To upgrade to VPN Plus"), Qt::CaseInsensitive)
+            ? AccountType::Free
+            : AccountType::Plus;
+        m_accountType = type;
+        emit accountTypeReady(type);
+    });
+}
+
+void VpnManager::fetchCliVersion()
+{
+    // `protonvpn` with no args prints the ASCII banner; the version number
+    // (semver) appears on the last banner line.
+    runCommand({}, [this](int, const QString& out, const QString& err)
+    {
+        const QString combined = out + QLatin1Char('\n') + err;
+        const QRegularExpression re(QStringLiteral(R"(\b(\d+\.\d+\.\d+)\b)"));
+        const QStringList lines = combined.split(QLatin1Char('\n'));
+        for (int i = lines.size() - 1; i >= 0; --i)
+        {
+            const auto match = re.match(lines[i]);
+            if (match.hasMatch())
+            {
+                emit cliVersionReady(match.captured(1));
+                return;
+            }
+        }
+        emit cliVersionReady(QString());
+    });
+}
+
+// ---------------------------------------------------------------------------
+// Config
+// ---------------------------------------------------------------------------
+
+void VpnManager::applyConfig(const QString& key, bool enabled)
+{
+    applyConfigValue(key, enabled ? QStringLiteral("on") : QStringLiteral("off"));
+}
+
+void VpnManager::applyConfigValue(const QString& key, const QString& value)
+{
+    QStringList args{QStringLiteral("config"), QStringLiteral("set"), key};
+    args << value.split(QLatin1Char(' '), Qt::SkipEmptyParts);
+
+    runCommand(args, [this](int, const QString& out, const QString& err)
+    {
+        const QString combined = (out + QLatin1Char('\n') + err).trimmed();
+        emit configApplied(combined);
+    });
+}
+
+// ---------------------------------------------------------------------------
+// Status (startup check + background poll)
+// ---------------------------------------------------------------------------
+
+void VpnManager::checkConnectionStatus()
+{
+    auto* process = new QProcess(this);
+    connect(process, QOverload<int, QProcess::ExitStatus>::of(&QProcess::finished),
+            this, [this, process](int, QProcess::ExitStatus)
+            {
+                const QString combined = QString::fromUtf8(process->readAllStandardOutput())
+                                         + QLatin1Char('\n')
+                                         + QString::fromUtf8(process->readAllStandardError());
+                process->deleteLater();
+
+                // Strip noise lines.
+                QStringList lines = combined.split(QLatin1Char('\n'));
+                lines.erase(std::ranges::remove_if(lines, [](const QString& l)
+                {
+                    const QString ll = l.toLower();
+                    return ll.contains(QLatin1String("outdated"))              ||
+                           ll.contains(QLatin1String("updating"))              ||
+                           ll.contains(QLatin1String("this may take"))         ||
+                           ll.contains(QLatin1String("to get your forwarded port")) ||
+                           ll.contains(QLatin1String("natpmpc"))               ||
+                           (ll.startsWith(QLatin1String("guide:")) && ll.contains(QLatin1String("http")));
+                }).begin(), lines.end());
+
+                // Parse "Key: Value" lines into a map.
+                QMap<QString, QString> fields;
+                for (const QString& line : std::as_const(lines))
+                {
+                    const int colonPos = line.indexOf(QLatin1Char(':'));
+                    if (colonPos < 0) continue;
+                    const QString key   = line.left(colonPos).trimmed().toLower();
+                    const QString value = line.mid(colonPos + 1).trimmed();
+                    if (!key.isEmpty() && !value.isEmpty())
+                        fields.insert(key, value);
+                }
+
+                const QString statusVal = fields.value(QStringLiteral("status")).toLower();
+
+                if (statusVal == QStringLiteral("connected"))
+                {
+                    m_state = VpnState::Connected;
+
+                    // "Server: US-NJ#203 in Secaucus, United States"
+                    const QString server = fields.value(QStringLiteral("server"));
+
+                    // Parse city from "… in City, Country"
+                    QString city;
+                    const int inPos = server.indexOf(QStringLiteral(" in "));
+                    if (inPos >= 0)
+                    {
+                        const QString rest    = server.mid(inPos + 4);
+                        const int    commaPos = rest.indexOf(QLatin1Char(','));
+                        city = (commaPos >= 0 ? rest.left(commaPos) : rest).trimmed();
+                    }
+
+                    // Extract country code from server name prefix, e.g. "US-NJ#203" → "US"
+                    QString countryCode;
+                    {
+                        const int dashPos = server.indexOf(QLatin1Char('-'));
+                        const int hashPos = server.indexOf(QLatin1Char('#'));
+                        const int endPos  = (dashPos >= 0 && (hashPos < 0 || dashPos < hashPos))
+                                            ? dashPos : hashPos;
+                        if (endPos > 0)
+                            countryCode = server.left(endPos).toUpper();
+                    }
+
+                    // Emit city and country before connectionStateChanged so the
+                    // VPN page can store them before updateUi() runs.
+                    if (!city.isEmpty())
+                        emit connectionCityKnown(city);
+                    if (!countryCode.isEmpty())
+                        emit connectionCountryKnown(countryCode);
+
+                    const QString info = server.isEmpty()
+                        ? QString()
+                        : QStringLiteral("Connected to %1.").arg(server);
+                    emit connectionStateChanged(m_state, info);
+                }
+                else
+                {
+                    m_state = VpnState::Disconnected;
+                    emit connectionStateChanged(m_state, QString());
+                }
+            });
+    process->start(QStringLiteral("protonvpn"), QStringList{QStringLiteral("status")});
+}
+
+void VpnManager::pollStatus()
+{
+    if (m_pollActive)
+        return;
+
+    m_pollActive = true;
+
+    auto* process = new QProcess(this);
+    connect(process, QOverload<int, QProcess::ExitStatus>::of(&QProcess::finished),
+            this, [this, process](int, QProcess::ExitStatus)
+            {
+                m_pollActive = false;
+
+                const QString combined =
+                    QString::fromUtf8(process->readAllStandardOutput()) + QLatin1Char('\n') +
+                    QString::fromUtf8(process->readAllStandardError());
+                process->deleteLater();
+
+                if (m_state == VpnState::Connecting || m_state == VpnState::Disconnecting)
+                    return;
+
+                QStringList lines = combined.split(QLatin1Char('\n'));
+                lines.erase(std::ranges::remove_if(lines, [](const QString& l)
+                {
+                    const QString ll = l.toLower();
+                    return ll.contains(QLatin1String("outdated"))  ||
+                           ll.contains(QLatin1String("updating"))  ||
+                           ll.contains(QLatin1String("this may take"));
+                }).begin(), lines.end());
+
+                QMap<QString, QString> fields;
+                for (const QString& line : std::as_const(lines))
+                {
+                    const int colonPos = line.indexOf(QLatin1Char(':'));
+                    if (colonPos < 0) continue;
+                    const QString key   = line.left(colonPos).trimmed().toLower();
+                    const QString value = line.mid(colonPos + 1).trimmed();
+                    if (!key.isEmpty() && !value.isEmpty())
+                        fields.insert(key, value);
+                }
+
+                const QString statusVal = fields.value(QStringLiteral("status")).toLower();
+                const VpnState newState = (statusVal == QStringLiteral("connected"))
+                                          ? VpnState::Connected
+                                          : VpnState::Disconnected;
+
+                QString server, city, info;
+                if (newState == VpnState::Connected)
+                {
+                    server = fields.value(QStringLiteral("server"));
+                    const int inPos = server.indexOf(QStringLiteral(" in "));
+                    if (inPos >= 0)
+                    {
+                        const QString rest    = server.mid(inPos + 4);
+                        const int    commaPos = rest.indexOf(QLatin1Char(','));
+                        city = (commaPos >= 0 ? rest.left(commaPos) : rest).trimmed();
+                    }
+                    info = server.isEmpty()
+                        ? QString()
+                        : QStringLiteral("Connected to %1.").arg(server);
+                }
+
+#ifdef QT_DEBUG
+                const VpnState dbgPrevState  = m_state;
+                const QString  dbgPrevServer = m_connectedServer;
+#endif
+
+                if (newState != m_state ||
+                    (newState == VpnState::Connected &&
+                     !m_connectedServer.isEmpty() &&
+                     server != m_connectedServer))
+                {
+                    m_state = newState;
+
+                    if (newState == VpnState::Connected)
+                    {
+                        m_connectedServer = server;
+                        if (!city.isEmpty())
+                            emit connectionCityKnown(city);
+                        emit connectionStateChanged(m_state, info);
+                    }
+                    else
+                    {
+                        m_connectedServer.clear();
+                        emit connectionStateChanged(m_state, QString());
+                    }
+                }
+                else if (newState == VpnState::Connected && m_connectedServer.isEmpty())
+                {
+                    m_connectedServer = server;
+                }
+
+#ifdef QT_DEBUG
+                {
+                    auto stateToStr = [](const VpnState s) -> const char*
+                    {
+                        switch (s)
+                        {
+                            case VpnState::Connected:     return "Connected";
+                            case VpnState::Disconnected:  return "Disconnected";
+                            case VpnState::Connecting:    return "Connecting";
+                            case VpnState::Disconnecting: return "Disconnecting";
+                            default:                      return "Error";
+                        }
+                    };
+                    const bool stateChanged  = newState != dbgPrevState;
+                    const bool serverChanged = !stateChanged &&
+                                              newState == VpnState::Connected &&
+                                              !dbgPrevServer.isEmpty() &&
+                                              server != dbgPrevServer;
+                    if (stateChanged)
+                        qDebug("[Status Polling] State changed:  %s → %s",
+                               stateToStr(dbgPrevState), stateToStr(newState));
+                    else if (serverChanged)
+                        qDebug("[Status Polling] Server changed: \"%s\" → \"%s\"",
+                               qUtf8Printable(dbgPrevServer), qUtf8Printable(server));
+                }
+#endif
+            });
+    process->start(QStringLiteral("protonvpn"), QStringList{QStringLiteral("status")});
+}
+

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -314,6 +314,17 @@ MainWindow::MainWindow(QWidget* parent)
         msgLabel->setTextFormat(Qt::RichText);
         layout->addWidget(msgLabel);
 
+        if (m_vpnPage->isPortForwardingActive())
+        {
+            auto* pfLabel = new QLabel(
+                QStringLiteral("<i>Note: the forwarded port lease will lapse shortly after "
+                               "the app closes, as the keep-alive loop will no longer be running.</i>"),
+                dlg);
+            pfLabel->setWordWrap(true);
+            pfLabel->setTextFormat(Qt::RichText);
+            layout->addWidget(pfLabel);
+        }
+
         auto* btnRow = new QHBoxLayout();
         btnRow->setSpacing(8);
 

--- a/src/pages/settingspage.cpp
+++ b/src/pages/settingspage.cpp
@@ -218,7 +218,7 @@ void SettingsPage::showReconnectDialog(const QString& settingLabel,
     connect(dismissBtn, &QPushButton::clicked, dlg, &QDialog::reject);
 
     auto* reconnectBtn = new QPushButton(
-        QStringLiteral("Disconnect, Apply && Reconnect"), dlg);
+        QStringLiteral("Apply && Reconnect"), dlg);
     reconnectBtn->setObjectName(QStringLiteral("primaryButton"));
     reconnectBtn->setDefault(true);
 

--- a/src/pages/settingspage.cpp
+++ b/src/pages/settingspage.cpp
@@ -933,8 +933,7 @@ SettingsPage::SettingsPage(VpnManager* manager, QWidget* parent)
     addPlus(makeToggleRow(m_plusSection,
                           QStringLiteral("Port Forwarding"),
                           QStringLiteral("Bypass firewalls to connect to P2P servers and devices in your local network. "
-                              "<a href='https://protonvpn.com/support/port-forwarding'>Learn more</a> · "
-                              "<a href='https://protonvpn.com/support/port-forwarding-manual-setup#linux'>Guide</a>"),
+                              "<a href='https://protonvpn.com/support/port-forwarding'>Learn more</a>"),
                           QStringLiteral("port-forwarding")));
 
     // ── Custom DNS ────────────────────────────────────────────

--- a/src/pages/settingspage.h
+++ b/src/pages/settingspage.h
@@ -141,7 +141,7 @@ private:
     QWidget* makeComboRow(QWidget* parent, const QString& label, const QString& desc,
                           const QString& cliKey, const QStringList& labels,
                           const QStringList& cliValues);
-    // Shows the standard "Disconnect, Apply & Reconnect" dialog for any setting
+    // Shows the standard "Apply & Reconnect" dialog for any setting
     // that cannot be changed while the VPN is active.  onAccept is called if
     // the user clicks the primary button; nothing extra is called on dismiss.
     void showReconnectDialog(const QString& settingLabel,

--- a/src/pages/vpnpage.cpp
+++ b/src/pages/vpnpage.cpp
@@ -24,6 +24,9 @@
 #include <QCursor>
 #include <QScrollArea>
 #include <QVersionNumber>
+#include <QProcess>
+#include <QRegularExpression>
+#include <QStandardPaths>
 #include <cmath>
 
 // ============================================================
@@ -751,6 +754,41 @@ VpnPage::VpnPage(VpnManager* manager, QWidget* parent)
     connect(m_errorDetailsBtn, &QPushButton::clicked, this, &VpnPage::showErrorDetails);
     scrollLayout->addWidget(m_errorDetailsBtn, 0, Qt::AlignCenter);
 
+    // ── Port forwarding row ───────────────────────────────────────────────
+    // Hidden by default; appears when natpmpc successfully allocates a port.
+    m_portRow = new QWidget(scrollContent);
+    auto* portRowLayout = new QHBoxLayout(m_portRow);
+    portRowLayout->setContentsMargins(0, 4, 0, 4);
+    portRowLayout->setSpacing(10);
+
+    auto* portTitleLabel = new QLabel(QStringLiteral("Forwarded Port:"), m_portRow);
+    portTitleLabel->setObjectName(QStringLiteral("infoLabel"));
+    portRowLayout->addWidget(portTitleLabel, 0, Qt::AlignVCenter);
+
+    m_portLabel = new QLabel(QStringLiteral("—"), m_portRow);
+    m_portLabel->setObjectName(QStringLiteral("portValueLabel"));
+    {
+        QFont f = m_portLabel->font();
+        f.setBold(true);
+        f.setPointSize(f.pointSize() + 1);
+        m_portLabel->setFont(f);
+    }
+    portRowLayout->addWidget(m_portLabel, 0, Qt::AlignVCenter);
+
+    auto* portCopyBtn = new QPushButton(QStringLiteral("Copy"), m_portRow);
+    portCopyBtn->setObjectName(QStringLiteral("secondaryButton"));
+    portCopyBtn->setFixedHeight(26);
+    portCopyBtn->setCursor(Qt::PointingHandCursor);
+    connect(portCopyBtn, &QPushButton::clicked, this, [this]()
+    {
+        if (m_forwardedPort > 0)
+            QGuiApplication::clipboard()->setText(QString::number(m_forwardedPort));
+    });
+    portRowLayout->addWidget(portCopyBtn, 0, Qt::AlignVCenter);
+
+    m_portRow->setVisible(false);
+    scrollLayout->addWidget(m_portRow, 0, Qt::AlignCenter);
+
     scrollLayout->addStretch(1);
 
     auto* scrollArea = new QScrollArea(this);
@@ -804,6 +842,13 @@ VpnPage::VpnPage(VpnManager* manager, QWidget* parent)
     connect(m_manager, &VpnManager::cliVersionReady, this, &VpnPage::onCliVersionReady);
     m_manager->fetchCliVersion();
 
+    // If the user enables port forwarding while already connected, kick off
+    // the natpmpc loop immediately rather than waiting for the next reconnect.
+    connect(m_manager, &VpnManager::configApplied, this, [this](const QString&)
+    {
+        if (m_currentState == VpnState::Connected)
+            startNatPmpLoop();
+    });
     // Show a banner if this is a pre-release build
     checkPrereleaseBanner();
 
@@ -1082,6 +1127,7 @@ void VpnPage::updateUi(const VpnState state, const QString& info)
         m_statusLabel->setText(QStringLiteral("Connected"));
         m_statusLabel->setStyleSheet(QStringLiteral("color: #1a9c5b; font-size: 16pt; font-weight: bold; letter-spacing: 1px;"));
         m_infoLabel->setText(info.isEmpty() ? QString() : info);
+        startNatPmpLoop();
         if (prevState == VpnState::Connecting)
         {
             startElapsedTimer();
@@ -1122,6 +1168,7 @@ void VpnPage::updateUi(const VpnState state, const QString& info)
         break;
 
     case VpnState::Disconnected:
+        stopNatPmpLoop();
         m_powerBtn->setState(PowerButton::RingState::Disconnected);
         m_powerBtn->setEnabled(true);
         m_statusLabel->setText(QStringLiteral("Disconnected"));
@@ -1139,6 +1186,7 @@ void VpnPage::updateUi(const VpnState state, const QString& info)
         break;
 
     case VpnState::Connecting:
+        stopNatPmpLoop();
         m_powerBtn->setState(PowerButton::RingState::Spinning);
         m_powerBtn->setEnabled(false);
         m_statusLabel->setText(QStringLiteral("Connecting…"));
@@ -1148,6 +1196,7 @@ void VpnPage::updateUi(const VpnState state, const QString& info)
         break;
 
     case VpnState::Disconnecting:
+        stopNatPmpLoop();
         m_powerBtn->setState(PowerButton::RingState::Spinning);
         m_powerBtn->setEnabled(false);
         m_statusLabel->setText(QStringLiteral("Disconnecting…"));
@@ -1157,6 +1206,7 @@ void VpnPage::updateUi(const VpnState state, const QString& info)
 
     case VpnState::Error:
     {
+        stopNatPmpLoop();
         m_powerBtn->setState(PowerButton::RingState::Disconnected);
         m_powerBtn->setEnabled(true);
         m_statusLabel->setText(QStringLiteral("Error"));
@@ -1263,3 +1313,127 @@ void VpnPage::applyFreeUserMode()
     // Re-run layout so picker widths are recalculated correctly.
     relayoutPickers(width());
 }
+
+// ---------------------------------------------------------------------------
+// Port forwarding (natpmpc keep-alive loop)
+// ---------------------------------------------------------------------------
+
+void VpnPage::startNatPmpLoop()
+{
+    if (m_natPmpTimer)
+        return; // already running
+
+    // If natpmpc is not installed, show a one-time warning banner and bail out.
+    // The banner is only created once per connect; dismissing it clears the
+    // pointer so it can appear again on the next connection if still missing.
+    if (QStandardPaths::findExecutable(QStringLiteral("natpmpc")).isEmpty())
+    {
+        if (!m_natpmpcBanner)
+        {
+            const auto* scrollArea = findChild<QScrollArea*>(QStringLiteral("vpnScrollArea"));
+            if (scrollArea && scrollArea->widget())
+            {
+                auto* scrollLayout = qobject_cast<QVBoxLayout*>(scrollArea->widget()->layout());
+                if (scrollLayout)
+                {
+                    m_natpmpcBanner = new InfoBanner(
+                        QStringLiteral(
+                            "<b>natpmpc is not installed.</b> "
+                            "The forwarded port cannot be displayed or kept alive automatically. "
+                            "Install it to use port forwarding "
+                            "(<code>sudo apt install natpmpc</code> on Debian/Ubuntu, "
+                            "<code>sudo dnf install libnatpmp</code> on Fedora, "
+                            "<code>sudo pacman -S libnatpmp</code> on Arch)."),
+                        this);
+                    connect(m_natpmpcBanner, &InfoBanner::dismissed, this, [this]()
+                    {
+                        m_natpmpcBanner = nullptr;
+                    });
+                    // Insert below any existing version/prerelease banners.
+                    int pos = 0;
+                    if (m_prereleaseBanner) ++pos;
+                    if (m_versionBanner)    ++pos;
+                    scrollLayout->insertWidget(pos, m_natpmpcBanner);
+                }
+            }
+        }
+        return; // don't start the loop without natpmpc
+    }
+
+    m_natPmpTimer = new QTimer(this);
+    // 45 s interval keeps a 60 s NAT-PMP lease comfortably alive.
+    m_natPmpTimer->setInterval(45'000);
+    connect(m_natPmpTimer, &QTimer::timeout, this, &VpnPage::runNatPmp);
+    m_natPmpTimer->start();
+
+    runNatPmp(); // fire immediately on connect
+}
+
+void VpnPage::stopNatPmpLoop()
+{
+    if (m_natPmpTimer)
+    {
+        m_natPmpTimer->stop();
+        m_natPmpTimer->deleteLater();
+        m_natPmpTimer = nullptr;
+    }
+    m_natPmpActive  = false;
+    m_forwardedPort = 0;
+    if (m_portRow) m_portRow->setVisible(false);
+}
+
+void VpnPage::runNatPmp()
+{
+    if (m_natPmpActive)
+        return; // previous invocation still in flight
+
+    m_natPmpActive = true;
+
+    auto* process = new QProcess(this);
+    connect(process, QOverload<int, QProcess::ExitStatus>::of(&QProcess::finished),
+            this, [this, process](int exitCode, QProcess::ExitStatus)
+    {
+        m_natPmpActive = false;
+        const QString out = QString::fromUtf8(process->readAllStandardOutput())
+                          + QString::fromUtf8(process->readAllStandardError());
+        process->deleteLater();
+
+        if (exitCode != 0)
+        {
+            // natpmpc not installed, server doesn't support port forwarding,
+            // or port forwarding is disabled in VPN settings — stay hidden.
+            if (m_forwardedPort != 0)
+            {
+                m_forwardedPort = 0;
+                if (m_portRow) m_portRow->setVisible(false);
+            }
+            return;
+        }
+
+        // Example natpmpc output line:
+        //   "Mapped public port 53186 protocol UDP lifetime 60"
+        const QRegularExpression re(QStringLiteral(R"(Mapped public port (\d+))"));
+        const QRegularExpressionMatch match = re.match(out);
+        if (match.hasMatch())
+        {
+            const int port = match.captured(1).toInt();
+            if (port != m_forwardedPort)
+            {
+                m_forwardedPort = port;
+                if (m_portLabel)
+                    m_portLabel->setText(QString::number(port));
+            }
+            if (m_portRow) m_portRow->setVisible(true);
+        }
+    });
+
+    // Run UDP mapping then TCP mapping in one shell invocation.
+    // Both mappings are required by the ProtonVPN port forwarding spec;
+    // the allocated port number is the same for both and is parsed from
+    // the UDP response.
+    process->start(QStringLiteral("/bin/sh"),
+                   {QStringLiteral("-c"),
+                    QStringLiteral("natpmpc -a 1 0 udp 60 -g 10.2.0.1 "
+                                   "&& natpmpc -a 1 0 tcp 60 -g 10.2.0.1")});
+}
+

--- a/src/pages/vpnpage.cpp
+++ b/src/pages/vpnpage.cpp
@@ -24,9 +24,6 @@
 #include <QCursor>
 #include <QScrollArea>
 #include <QVersionNumber>
-#include <QProcess>
-#include <QRegularExpression>
-#include <QStandardPaths>
 #include <cmath>
 
 // ============================================================
@@ -781,8 +778,9 @@ VpnPage::VpnPage(VpnManager* manager, QWidget* parent)
     portCopyBtn->setCursor(Qt::PointingHandCursor);
     connect(portCopyBtn, &QPushButton::clicked, this, [this]()
     {
-        if (m_forwardedPort > 0)
-            QGuiApplication::clipboard()->setText(QString::number(m_forwardedPort));
+        if (m_natPmpManager && m_natPmpManager->forwardedPort() > 0)
+            QGuiApplication::clipboard()->setText(
+                QString::number(m_natPmpManager->forwardedPort()));
     });
     portRowLayout->addWidget(portCopyBtn, 0, Qt::AlignVCenter);
 
@@ -848,6 +846,58 @@ VpnPage::VpnPage(VpnManager* manager, QWidget* parent)
     {
         if (m_currentState == VpnState::Connected)
             startNatPmpLoop();
+    });
+
+    // Track the country code of the currently connected server so we can look
+    // up city features via fetchCityFeatures() on startup.
+    connect(m_manager, &VpnManager::connectionCountryKnown, this, [this](const QString& cc)
+    {
+        m_connectedCountryCode = cc;
+    });
+
+    // ── NatPmpManager ────────────────────────────────────────────────────
+    m_natPmpManager = new NatPmpManager(this);
+
+    connect(m_natPmpManager, &NatPmpManager::portAcquired, this, [this](int port)
+    {
+        if (m_portLabel)
+            m_portLabel->setText(QString::number(port));
+        if (m_portRow)
+            m_portRow->setVisible(true);
+    });
+
+    connect(m_natPmpManager, &NatPmpManager::portLost, this, [this]()
+    {
+        if (m_portRow)
+            m_portRow->setVisible(false);
+    });
+
+    connect(m_natPmpManager, &NatPmpManager::natpmpcMissing, this, [this]()
+    {
+        if (m_natpmpcBanner)
+            return; // already showing
+        const auto* scrollArea = findChild<QScrollArea*>(QStringLiteral("vpnScrollArea"));
+        if (!scrollArea || !scrollArea->widget()) return;
+        auto* scrollLayout = qobject_cast<QVBoxLayout*>(scrollArea->widget()->layout());
+        if (!scrollLayout) return;
+
+        m_natpmpcBanner = new InfoBanner(
+            QStringLiteral(
+                "<b>natpmpc is not installed.</b> "
+                "The forwarded port cannot be displayed or kept alive automatically. "
+                "Install it to use port forwarding "
+                "(<code>sudo apt install natpmpc</code> on Debian/Ubuntu, "
+                "<code>sudo dnf install libnatpmp</code> on Fedora, "
+                "<code>sudo pacman -S libnatpmp</code> on Arch)."),
+            this);
+        connect(m_natpmpcBanner, &InfoBanner::dismissed, this, [this]()
+        {
+            m_natpmpcBanner = nullptr;
+        });
+        int pos = 0;
+        if (m_prereleaseBanner) ++pos;
+        if (m_versionBanner)    ++pos;
+        scrollLayout->insertWidget(pos, m_natpmpcBanner);
     });
     // Show a banner if this is a pre-release build
     checkPrereleaseBanner();
@@ -1025,6 +1075,23 @@ void VpnPage::onCitiesReady(const QString& countryCode,
 
     m_locationPicker->populate(cities);
     applyPendingStatusCity();
+
+    // Update the tracked features for the currently active city so
+    // refreshConnectedInfoLabel() can show "Port forwarding is active" when
+    // the app starts with the VPN already connected to a P2P server.
+    if (!m_activeCity.isEmpty())
+    {
+        for (const auto& [city, features] : cities)
+        {
+            if (city.compare(m_activeCity, Qt::CaseInsensitive) == 0)
+            {
+                m_currentCityFeatures = features;
+                break;
+            }
+        }
+    }
+    if (m_currentState == VpnState::Connected)
+        refreshConnectedInfoLabel();
 }
 
 void VpnPage::checkPrereleaseBanner()
@@ -1126,8 +1193,29 @@ void VpnPage::updateUi(const VpnState state, const QString& info)
         m_powerBtn->setEnabled(true);
         m_statusLabel->setText(QStringLiteral("Connected"));
         m_statusLabel->setStyleSheet(QStringLiteral("color: #1a9c5b; font-size: 16pt; font-weight: bold; letter-spacing: 1px;"));
-        m_infoLabel->setText(info.isEmpty() ? QString() : info);
+        m_lastConnectedInfo = info;
+        refreshConnectedInfoLabel();
         startNatPmpLoop();
+
+        // On app startup with VPN already connected, the CLI connect output is
+        // not available, so "Port forwarding is active on this server." won't be
+        // in `info`.  Fetch the city features explicitly and update the label once
+        // we know whether it's a P2P server.
+        if (m_manager->portForwardingEnabled() &&
+            !m_connectedCountryCode.isEmpty() && !m_activeCity.isEmpty())
+        {
+            const QString cc   = m_connectedCountryCode;
+            const QString city = m_activeCity;
+            m_manager->fetchCityFeatures(cc, city, [this, cc, city](const QString& features)
+            {
+                // Guard: still connected to the same server when the result arrives.
+                if (m_currentState != VpnState::Connected ||
+                    m_connectedCountryCode != cc || m_activeCity != city)
+                    return;
+                m_currentCityFeatures = features;
+                refreshConnectedInfoLabel();
+            });
+        }
         if (prevState == VpnState::Connecting)
         {
             startElapsedTimer();
@@ -1315,125 +1403,46 @@ void VpnPage::applyFreeUserMode()
 }
 
 // ---------------------------------------------------------------------------
-// Port forwarding (natpmpc keep-alive loop)
+// Port forwarding — NatPmpManager integration
 // ---------------------------------------------------------------------------
+
+void VpnPage::refreshConnectedInfoLabel()
+{
+    QString text = m_lastConnectedInfo;
+
+    // Append the port-forwarding notice if:
+    //   1. The setting is enabled in the VPN configuration, AND
+    //   2. The active city's server features include P2P, AND
+    //   3. The text doesn't already contain the notice (avoids duplicates from
+    //      the live CLI connect path, which already includes it).
+    const bool pfEnabled = m_manager->portForwardingEnabled();
+    const bool isP2P     = m_currentCityFeatures.contains(
+                               QLatin1String("p2p"), Qt::CaseInsensitive);
+    const QString pfNote = QStringLiteral("Port forwarding is active on this server.");
+    if (pfEnabled && isP2P && !text.contains(pfNote))
+    {
+        if (!text.isEmpty())
+            text += QLatin1Char('\n');
+        text += pfNote;
+    }
+
+    m_infoLabel->setText(text);
+}
 
 void VpnPage::startNatPmpLoop()
 {
-    if (m_natPmpTimer)
-        return; // already running
-
-    // If natpmpc is not installed, show a one-time warning banner and bail out.
-    // The banner is only created once per connect; dismissing it clears the
-    // pointer so it can appear again on the next connection if still missing.
-    if (QStandardPaths::findExecutable(QStringLiteral("natpmpc")).isEmpty())
-    {
-        if (!m_natpmpcBanner)
-        {
-            const auto* scrollArea = findChild<QScrollArea*>(QStringLiteral("vpnScrollArea"));
-            if (scrollArea && scrollArea->widget())
-            {
-                auto* scrollLayout = qobject_cast<QVBoxLayout*>(scrollArea->widget()->layout());
-                if (scrollLayout)
-                {
-                    m_natpmpcBanner = new InfoBanner(
-                        QStringLiteral(
-                            "<b>natpmpc is not installed.</b> "
-                            "The forwarded port cannot be displayed or kept alive automatically. "
-                            "Install it to use port forwarding "
-                            "(<code>sudo apt install natpmpc</code> on Debian/Ubuntu, "
-                            "<code>sudo dnf install libnatpmp</code> on Fedora, "
-                            "<code>sudo pacman -S libnatpmp</code> on Arch)."),
-                        this);
-                    connect(m_natpmpcBanner, &InfoBanner::dismissed, this, [this]()
-                    {
-                        m_natpmpcBanner = nullptr;
-                    });
-                    // Insert below any existing version/prerelease banners.
-                    int pos = 0;
-                    if (m_prereleaseBanner) ++pos;
-                    if (m_versionBanner)    ++pos;
-                    scrollLayout->insertWidget(pos, m_natpmpcBanner);
-                }
-            }
-        }
-        return; // don't start the loop without natpmpc
-    }
-
-    m_natPmpTimer = new QTimer(this);
-    // 45 s interval keeps a 60 s NAT-PMP lease comfortably alive.
-    m_natPmpTimer->setInterval(45'000);
-    connect(m_natPmpTimer, &QTimer::timeout, this, &VpnPage::runNatPmp);
-    m_natPmpTimer->start();
-
-    runNatPmp(); // fire immediately on connect
+    m_natPmpManager->start();
 }
 
 void VpnPage::stopNatPmpLoop()
 {
-    if (m_natPmpTimer)
-    {
-        m_natPmpTimer->stop();
-        m_natPmpTimer->deleteLater();
-        m_natPmpTimer = nullptr;
-    }
-    m_natPmpActive  = false;
-    m_forwardedPort = 0;
-    if (m_portRow) m_portRow->setVisible(false);
-}
+    m_natPmpManager->stop();
 
-void VpnPage::runNatPmp()
-{
-    if (m_natPmpActive)
-        return; // previous invocation still in flight
+    m_currentCityFeatures.clear();
+    m_lastConnectedInfo.clear();
+    m_connectedCountryCode.clear();
 
-    m_natPmpActive = true;
-
-    auto* process = new QProcess(this);
-    connect(process, QOverload<int, QProcess::ExitStatus>::of(&QProcess::finished),
-            this, [this, process](int exitCode, QProcess::ExitStatus)
-    {
-        m_natPmpActive = false;
-        const QString out = QString::fromUtf8(process->readAllStandardOutput())
-                          + QString::fromUtf8(process->readAllStandardError());
-        process->deleteLater();
-
-        if (exitCode != 0)
-        {
-            // natpmpc not installed, server doesn't support port forwarding,
-            // or port forwarding is disabled in VPN settings — stay hidden.
-            if (m_forwardedPort != 0)
-            {
-                m_forwardedPort = 0;
-                if (m_portRow) m_portRow->setVisible(false);
-            }
-            return;
-        }
-
-        // Example natpmpc output line:
-        //   "Mapped public port 53186 protocol UDP lifetime 60"
-        const QRegularExpression re(QStringLiteral(R"(Mapped public port (\d+))"));
-        const QRegularExpressionMatch match = re.match(out);
-        if (match.hasMatch())
-        {
-            const int port = match.captured(1).toInt();
-            if (port != m_forwardedPort)
-            {
-                m_forwardedPort = port;
-                if (m_portLabel)
-                    m_portLabel->setText(QString::number(port));
-            }
-            if (m_portRow) m_portRow->setVisible(true);
-        }
-    });
-
-    // Run UDP mapping then TCP mapping in one shell invocation.
-    // Both mappings are required by the ProtonVPN port forwarding spec;
-    // the allocated port number is the same for both and is parsed from
-    // the UDP response.
-    process->start(QStringLiteral("/bin/sh"),
-                   {QStringLiteral("-c"),
-                    QStringLiteral("natpmpc -a 1 0 udp 60 -g 10.2.0.1 "
-                                   "&& natpmpc -a 1 0 tcp 60 -g 10.2.0.1")});
+    if (m_portRow)
+        m_portRow->setVisible(false);
 }
 

--- a/src/pages/vpnpage.h
+++ b/src/pages/vpnpage.h
@@ -14,9 +14,8 @@
 #include <QGuiApplication>
 #include <QVersionNumber>
 #include <QHBoxLayout>
-#include <QProcess>
-#include <QRegularExpression>
 #include "../vpnmanager.h"
+#include "../cli/natpmpmanager.h"
 #include "../widgets/elidalabel.h"
 #include "../widgets/pickerbase.h"
 #include "../widgets/infobanner.h"
@@ -134,7 +133,7 @@ public:
     // Called when VpnManager has parsed a city from `protonvpn status`.
     void onStatusCityKnown(const QString& city);
     // Returns true while the natpmpc keep-alive loop is running (port forwarding active).
-    bool isPortForwardingActive() const { return m_natPmpTimer != nullptr; }
+    bool isPortForwardingActive() const { return m_natPmpManager && m_natPmpManager->isRunning(); }
 
 signals:
     void connectRequested(const QString& country, const QString& city);
@@ -171,17 +170,18 @@ private:
     int   m_checkingSpinnerFrame = 0;
     QString m_rawError;
 
-    // Port forwarding (natpmpc keep-alive loop)
-    QWidget*     m_portRow       = nullptr;
-    QLabel*      m_portLabel     = nullptr;
-    QTimer*      m_natPmpTimer   = nullptr;
-    bool         m_natPmpActive  = false;
-    int          m_forwardedPort = 0;
-    InfoBanner*  m_natpmpcBanner = nullptr;
+    // Port forwarding (NatPmpManager keep-alive loop)
+    QWidget*        m_portRow       = nullptr;
+    QLabel*         m_portLabel     = nullptr;
+    NatPmpManager*  m_natPmpManager = nullptr;
+    InfoBanner*     m_natpmpcBanner = nullptr;
 
     VpnState m_currentState = VpnState::Unknown;
     QString  m_activeCity;
+    QString  m_connectedCountryCode; // country code of the currently connected server (e.g. "US")
     QString  m_pendingStatusCity; // city from protonvpn status, applied after cities populate
+    QString  m_currentCityFeatures; // features string (e.g. "P2P") for the currently active city
+    QString  m_lastConnectedInfo;   // base info text from the last Connected state change
     bool     m_hadUnknownConnection = false;
     bool     m_stateKnown = false;
     // nullopt = citiesReady has not yet fired for the local country;
@@ -200,7 +200,7 @@ private:
     void applyFreeUserMode();
     void startNatPmpLoop();
     void stopNatPmpLoop();
-    void runNatPmp();
+    void refreshConnectedInfoLabel();
     // After populate(), try to select m_pendingStatusCity; falls back to
     void applyPendingStatusCity();
 };

--- a/src/pages/vpnpage.h
+++ b/src/pages/vpnpage.h
@@ -14,6 +14,8 @@
 #include <QGuiApplication>
 #include <QVersionNumber>
 #include <QHBoxLayout>
+#include <QProcess>
+#include <QRegularExpression>
 #include "../vpnmanager.h"
 #include "../widgets/elidalabel.h"
 #include "../widgets/pickerbase.h"
@@ -131,6 +133,8 @@ public:
     void refreshRecentPicker();
     // Called when VpnManager has parsed a city from `protonvpn status`.
     void onStatusCityKnown(const QString& city);
+    // Returns true while the natpmpc keep-alive loop is running (port forwarding active).
+    bool isPortForwardingActive() const { return m_natPmpTimer != nullptr; }
 
 signals:
     void connectRequested(const QString& country, const QString& city);
@@ -167,6 +171,14 @@ private:
     int   m_checkingSpinnerFrame = 0;
     QString m_rawError;
 
+    // Port forwarding (natpmpc keep-alive loop)
+    QWidget*     m_portRow       = nullptr;
+    QLabel*      m_portLabel     = nullptr;
+    QTimer*      m_natPmpTimer   = nullptr;
+    bool         m_natPmpActive  = false;
+    int          m_forwardedPort = 0;
+    InfoBanner*  m_natpmpcBanner = nullptr;
+
     VpnState m_currentState = VpnState::Unknown;
     QString  m_activeCity;
     QString  m_pendingStatusCity; // city from protonvpn status, applied after cities populate
@@ -186,6 +198,9 @@ private:
     void checkPrereleaseBanner();
     void handleFreePlanError();
     void applyFreeUserMode();
+    void startNatPmpLoop();
+    void stopNatPmpLoop();
+    void runNatPmp();
     // After populate(), try to select m_pendingStatusCity; falls back to
     void applyPendingStatusCity();
 };

--- a/src/version.json
+++ b/src/version.json
@@ -1,5 +1,5 @@
 {
-    "app_version": "1.7.1-beta.1",
+    "app_version": "1.8.0-beta.2",
     "prerelease": true,
     "cli_version_tested": "1.0.0"
 }

--- a/src/version.json
+++ b/src/version.json
@@ -1,5 +1,5 @@
 {
-    "app_version": "1.8.0-beta.2",
+    "app_version": "1.8.0-rc.1",
     "prerelease": true,
     "cli_version_tested": "1.0.0"
 }

--- a/src/version.json
+++ b/src/version.json
@@ -1,6 +1,6 @@
 {
-    "app_version": "1.7.0",
-    "prerelease": false,
+    "app_version": "1.7.1-beta.1",
+    "prerelease": true,
     "cli_version_tested": "1.0.0"
 }
 

--- a/src/vpnmanager.cpp
+++ b/src/vpnmanager.cpp
@@ -1,17 +1,19 @@
+// vpnmanager.cpp
+// VpnManager: construction, settings file access, and background polling
+// infrastructure.
+//
+// All functions that interact with the protonvpn CLI live in protonvpncli.cpp.
+
 #include "vpnmanager.h"
 
-#include <QProcess>
-#include <QTimer>
 #include <QDir>
-#include <QJsonDocument> // Ignore unused include warning; we do use QJsonDocument
+#include <QFile>
+#include <QJsonDocument>
 #include <QJsonObject>
 #include <QJsonArray>
-#include <QStandardPaths>
-#include <functional>
-#include <ranges>
+#include <QTimer>
 
 // Path to the ProtonVPN settings file, relative to the user's home directory.
-// Change this constant if the CLI ever moves the file.
 static const QString kSettingsPath =
     QDir::homePath() + QStringLiteral("/.config/Proton/VPN/settings.json");
 
@@ -20,530 +22,8 @@ VpnManager::VpnManager(QObject* parent)
 {
 }
 
-void VpnManager::runCommand(const QStringList& args,
-                            std::function<void(int, const QString&, const QString&)> callback)
-{
-    auto* process = new QProcess(this);
-    connect(process, QOverload<int, QProcess::ExitStatus>::of(&QProcess::finished),
-            this, [process, callback](int exitCode, QProcess::ExitStatus)
-            {
-                const QString out = QString::fromUtf8(process->readAllStandardOutput()).trimmed();
-                const QString err = QString::fromUtf8(process->readAllStandardError()).trimmed();
-                callback(exitCode, out, err);
-                process->deleteLater();
-            });
-    process->start(QStringLiteral("protonvpn"), args);
-}
-
-void VpnManager::checkInstalled()
-{
-    auto* process = new QProcess(this);
-    connect(process, QOverload<int, QProcess::ExitStatus>::of(&QProcess::finished),
-            this, [this, process](int exitCode, QProcess::ExitStatus)
-            {
-                Q_UNUSED(exitCode)
-                QString out = QString::fromUtf8(process->readAllStandardOutput());
-                QString err = QString::fromUtf8(process->readAllStandardError());
-                // If we got any output at all, the tool is installed
-                bool installed = !out.isEmpty() || !err.isEmpty();
-                process->deleteLater();
-                emit installedResult(installed);
-            });
-    // Use --help which always exits 0 and prints usage
-    process->start(QStringLiteral("protonvpn"), QStringList{QStringLiteral("--help")});
-    if (!process->waitForStarted(2000))
-    {
-        process->deleteLater();
-        emit installedResult(false);
-    }
-}
-
-void VpnManager::checkLoginStatus()
-{
-    runCommand({QStringLiteral("info")}, [this](int, const QString& out, const QString&)
-    {
-        // New CLI format: "Account: 'username@example.com'"
-        // Not logged in → no match (or the value is empty / None).
-        bool loggedIn = false;
-        QString username;
-
-        const QRegularExpression re(QStringLiteral(R"(Account:\s*'([^']+)')"));
-        const auto match = re.match(out);
-        if (match.hasMatch())
-        {
-            const QString accountVal = match.captured(1).trimmed();
-            if (accountVal != QStringLiteral("None") && !accountVal.isEmpty())
-            {
-                loggedIn = true;
-                username = accountVal;
-            }
-        }
-
-        // Kick off an async `protonvpn status` check so the VPN page can show
-        // the correct connected/disconnected state as soon as the result arrives.
-        if (loggedIn)
-        {
-            checkConnectionStatus();
-            startPolling();
-            fetchAccountType();
-        }
-
-        emit loginStatusResult(loggedIn, username);
-    });
-}
-
-void VpnManager::login(const QString& username, const QString& password)
-{
-    // CLI flow: protonvpn signin <username>
-    //   stderr line 1: "Password: "   → we write password + '\n' to stdin
-    //   stderr line 2: "2FA Token: "  → optional; we emit twoFactorRequired()
-    //                                   and later submit2FA() writes the token
-    //
-    // Python's getpass.unix_getpass() tries /dev/tty first. Under QProcess
-    // there is no controlling TTY, so it falls back to writing the prompt on
-    // sys.stderr and reading the answer from sys.stdin — both of which are
-    // the pipes QProcess controls. That means we CAN see the prompts; we just
-    // have to watch stderr (not stdout).
-
-    if (m_signinProcess)
-    {
-        m_signinProcess->kill();
-        m_signinProcess->deleteLater();
-        m_signinProcess = nullptr;
-    }
-
-    m_signinProcess = new QProcess(this);
-    QProcess* process = m_signinProcess;
-
-    // Shared state — heap-allocated so lambdas can share across two signals.
-    struct State
-    {
-        QString accumulated;
-        bool passwordSent = false;
-        bool twoFAEmitted = false;
-    };
-    auto* state = new State();
-
-    // Helper that processes whatever has arrived so far.
-    // Called from both readyReadStandardOutput and readyReadStandardError.
-    auto processOutput = [this, process, state, password]()
-    {
-        // "Password: " prompt arrives on stderr (getpass fallback).
-        if (!state->passwordSent &&
-            state->accumulated.contains(QStringLiteral("Password:")))
-        {
-            state->passwordSent = true;
-            process->write((password + QLatin1Char('\n')).toUtf8());
-        }
-
-        // "2FA Token: " prompt also arrives on stderr, after the password
-        // has been accepted.
-        if (!state->twoFAEmitted &&
-            state->accumulated.contains(QStringLiteral("2FA Token:")))
-        {
-            state->twoFAEmitted = true;
-            emit twoFactorRequired();
-        }
-    };
-
-    connect(process, &QProcess::readyReadStandardOutput, this,
-            [process, state, processOutput]()
-            {
-                state->accumulated.append(QString::fromUtf8(process->readAllStandardOutput()));
-                processOutput();
-            });
-
-    connect(process, &QProcess::readyReadStandardError, this,
-            [process, state, processOutput]()
-            {
-                state->accumulated.append(QString::fromUtf8(process->readAllStandardError()));
-                processOutput();
-            });
-
-    connect(process, QOverload<int, QProcess::ExitStatus>::of(&QProcess::finished),
-            this, [this, process, state](const int exitCode, QProcess::ExitStatus)
-            {
-                const QString combined = state->accumulated.trimmed();
-                delete state;
-
-                if (process == m_signinProcess)
-                    m_signinProcess = nullptr;
-                process->deleteLater();
-
-                const bool ok = exitCode == 0;
-                QString errorMsg;
-                if (!ok)
-                {
-                    // Return the last meaningful line, skipping echoed prompt lines.
-                    const QStringList lines = combined.split(QLatin1Char('\n'), Qt::SkipEmptyParts);
-                    for (const auto & line : std::ranges::reverse_view(lines))
-                    {
-                        const QString l = line.trimmed();
-                        if (!l.isEmpty()
-                            && !l.startsWith(QStringLiteral("Password:"))
-                            && !l.startsWith(QStringLiteral("2FA")))
-                        {
-                            errorMsg = l;
-                            break;
-                        }
-                    }
-                    if (errorMsg.isEmpty()) errorMsg = combined;
-                }
-                else
-                {
-                    // Start background polling now that we're logged in.
-                    checkConnectionStatus();
-                    startPolling();
-                    fetchAccountType();
-                }
-                emit loginFinished(ok, errorMsg);
-            });
-
-    process->start(QStringLiteral("protonvpn"),
-                   QStringList{QStringLiteral("signin"), username});
-}
-
-void VpnManager::submit2FA(const QString& token) const
-{
-    if (m_signinProcess && m_signinProcess->state() == QProcess::Running)
-    {
-        m_signinProcess->write((token + QStringLiteral("\n")).toUtf8());
-    }
-}
-
-void VpnManager::signOut()
-{
-    stopPolling();
-    runCommand({QStringLiteral("signout")}, [this](int exitCode, const QString&, const QString&)
-    {
-        m_state = VpnState::Disconnected;
-        emit signOutFinished(exitCode == 0);
-    });
-}
-
-void VpnManager::connectVpn(const QString& country, const QString& city)
-{
-    // Remember the location so changeKillSwitchAndReconnect can restore it.
-    m_lastConnectCountry = country;
-    m_lastConnectCity    = city;
-
-    // Clear the tracked server so the first poll after this app-initiated
-    // connection silently learns the new server instead of treating the change
-    // as an external location switch (which would spuriously re-fire the
-    // connectionStateChanged / connectionCityKnown signals).
-    m_connectedServer.clear();
-
-    m_state = VpnState::Connecting;
-    emit connectionStateChanged(m_state, QString());
-
-    QStringList args{QStringLiteral("connect")};
-    if (!country.isEmpty())
-        args << QStringLiteral("--country") << country;
-    if (!city.isEmpty())
-        args << QStringLiteral("--city") << city;
-
-    runCommand(args, [this](int exitCode, const QString& out, const QString& err)
-    {
-        if (exitCode == 0)
-        {
-            m_state = VpnState::Connected;
-            // Strip any "server list is outdated" / "updating" noise lines the
-            // CLI sometimes prepends before the actual connection info.
-            QStringList lines = out.split(QLatin1Char('\n'));
-            lines.erase(std::ranges::remove_if(lines, [](const QString& l)
-            {
-                const QString ll = l.toLower();
-                return ll.contains(QLatin1String("outdated")) ||
-                    ll.contains(QLatin1String("updating")) ||
-                    ll.contains(QLatin1String("this may take")) ||
-                    ll.contains(QLatin1String("to get your forwarded port")) ||
-                    ll.contains(QLatin1String("natpmpc")) ||
-                    (ll.startsWith(QLatin1String("guide:")) && ll.contains(QLatin1String("http")));
-            }).begin(), lines.end());
-            // Remove leading/trailing blank lines left after filtering
-            while (!lines.isEmpty() && lines.first().trimmed().isEmpty())
-                lines.removeFirst();
-            emit connectionStateChanged(m_state, lines.join(QLatin1Char('\n')));
-        }
-        else
-        {
-            m_state = VpnState::Error;
-            emit connectionStateChanged(m_state, err.isEmpty() ? out : err);
-            emit errorOccurred(err.isEmpty() ? out : err);
-        }
-    });
-}
-
-void VpnManager::disconnectVpn()
-{
-    m_state = VpnState::Disconnecting;
-    emit connectionStateChanged(m_state, QString());
-
-    runCommand({QStringLiteral("disconnect")}, [this](const int exitCode, const QString& out, const QString& err)
-    {
-        if (exitCode == 0)
-        {
-            m_state = VpnState::Disconnected;
-            emit connectionStateChanged(m_state, out);
-        }
-        else
-        {
-            m_state = VpnState::Error;
-            emit connectionStateChanged(m_state, err.isEmpty() ? out : err);
-            emit errorOccurred(err.isEmpty() ? out : err);
-        }
-    });
-}
-
-void VpnManager::disconnectVpnSync()
-{
-    // Used at application exit — we need the process to complete before the
-    // event loop tears down, so run it synchronously.
-    QProcess process;
-    process.start(QStringLiteral("protonvpn"), QStringList{QStringLiteral("disconnect")});
-    process.waitForFinished(10000); // up to 10 s
-}
-
-void VpnManager::applyConfigValueAndReconnect(const QString& key, const QString& value)
-{
-    // Snapshot the reconnect target before we clear m_connectedServer.
-    const QString country = m_lastConnectCountry;
-    const QString city    = m_lastConnectCity;
-
-    m_state = VpnState::Disconnecting;
-    emit connectionStateChanged(m_state, QString());
-
-    runCommand({QStringLiteral("disconnect")},
-               [this, key, value, country, city](int exitCode, const QString&, const QString& err)
-    {
-        if (exitCode != 0)
-        {
-            m_state = VpnState::Error;
-            emit connectionStateChanged(m_state, err);
-            emit errorOccurred(err);
-            return;
-        }
-
-        m_state = VpnState::Disconnected;
-        emit connectionStateChanged(m_state, QString());
-
-        // Apply the config setting now that we're disconnected.
-        QStringList args{QStringLiteral("config"), QStringLiteral("set")};
-        args << key;
-        args << value.split(QLatin1Char(' '), Qt::SkipEmptyParts);
-
-        runCommand(args, [this, country, city](int, const QString& out, const QString& err2)
-        {
-            emit configApplied((out + QLatin1Char('\n') + err2).trimmed());
-            // Reconnect to wherever the user was before.
-            connectVpn(country, city);
-        });
-    });
-}
-
-void VpnManager::fetchCountries()
-{
-    runCommand({QStringLiteral("countries"), QStringLiteral("list")},
-               [this](int, const QString& out, const QString& err)
-    {
-        // Combine stdout + stderr — the "Server list is outdated, updating..."
-        // notice can appear on either stream.
-        const QString combined = out + QLatin1Char('\n') + err;
-        QMap<QString, QString> countries; // name → code
-        const QStringList lines = combined.split(QLatin1Char('\n'));
-        // Output format (after any update notice lines):
-        //   Country                 Code
-        //   ----------------------  ------
-        //   Afghanistan             AF
-        // We anchor to the separator line (starts with "--") and only parse
-        // lines that come after it, skipping any status/notice messages.
-        bool pastSeparator = false;
-        for (const QString& line : lines)
-        {
-            const QString trimmed = line.trimmed();
-            if (trimmed.isEmpty())
-                continue;
-            if (trimmed.startsWith(QStringLiteral("--")))
-            {
-                pastSeparator = true;
-                continue;
-            }
-            if (!pastSeparator)
-                continue; // skip header and any update-notice lines above it
-            // Name and code are separated by 2+ spaces.
-            const QStringList parts = line.split(QStringLiteral("  "), Qt::SkipEmptyParts);
-            if (parts.size() < 2)
-                continue;
-            const QString name = parts.first().trimmed();
-            const QString code = parts.last().trimmed();
-            if (!name.isEmpty() && !code.isEmpty())
-                countries.insert(name, code);
-        }
-        emit countriesReady(countries);
-    });
-}
-
-void VpnManager::fetchCities(const QString& countryCode)
-{
-    runCommand({QStringLiteral("cities"), QStringLiteral("list"), countryCode},
-               [this, countryCode](int, const QString& out, const QString& err)
-               {
-                   // Combine stdout + stderr to catch any "updating..." notices.
-                   const QString combined = out + QLatin1Char('\n') + err;
-                   QList<QPair<QString, QString>> cities;
-                   const QStringList lines = combined.split(QLatin1Char('\n'));
-                   // Output format (after any update notice lines):
-                   //   Cities in United States:
-                   //   City            Features
-                   //   --------------  ----------------
-                   //   Ashburn         P2P
-                   //   New York        P2P, Secure Core
-                   // We anchor to the separator line (starts with "--") and only
-                   // parse lines that come after it.
-                   bool pastSeparator = false;
-                   for (const QString& line : lines)
-                   {
-                       const QString trimmed = line.trimmed();
-                       if (trimmed.isEmpty())
-                           continue;
-                       if (trimmed.startsWith(QStringLiteral("--")))
-                       {
-                           pastSeparator = true;
-                           continue;
-                       }
-                       if (!pastSeparator)
-                           continue; // skip intro/header/notice lines
-                       // City and Features are separated by 2+ spaces.
-                       const QStringList parts = line.split(QStringLiteral("  "), Qt::SkipEmptyParts);
-                       const QString city = parts.value(0).trimmed();
-                       const QString features = parts.value(1).trimmed();
-                       if (!city.isEmpty())
-                           cities.append({city, features});
-                   }
-                   emit citiesReady(countryCode, cities);
-               });
-}
-
-void VpnManager::fetchInfo()
-{
-    runCommand({QStringLiteral("info")}, [this](int, const QString& out, const QString&)
-    {
-        // New CLI format: lines like "Account: 'username@example.com'"
-        QMap<QString, QString> result;
-        const QRegularExpression re(QStringLiteral(R"((\w[\w ]*):\s*'([^']*)')"));
-        QRegularExpressionMatchIterator it = re.globalMatch(out);
-        while (it.hasNext())
-        {
-            const auto m = it.next();
-            result.insert(m.captured(1).trimmed(), m.captured(2).trimmed());
-        }
-        emit infoReady(result);
-    });
-}
-
-void VpnManager::fetchAccountType()
-{
-    runCommand({QStringLiteral("config"), QStringLiteral("list")},
-               [this](int, const QString& out, const QString& err)
-    {
-        // If the output contains the "upgrade to VPN Plus" text, the user is on
-        // the Free plan.  Otherwise they are on Plus (or higher).
-        const QString combined = out + QLatin1Char('\n') + err;
-        const AccountType type =
-            combined.contains(QStringLiteral("To upgrade to VPN Plus"), Qt::CaseInsensitive)
-            ? AccountType::Free
-            : AccountType::Plus;
-
-        m_accountType = type;
-        emit accountTypeReady(type);
-    });
-}
-
-void VpnManager::checkConnectionStatus()
-{
-    auto* process = new QProcess(this);
-    // We connect to `finished`, not `readyRead`, so we receive the complete
-    // output in one go.  When the CLI needs to refresh its server list it
-    // prints "Server list is outdated, updating…" and pauses for a second or
-    // two before printing the actual status lines.  Because the process does
-    // not exit until all output has been written, `finished` fires only once
-    // everything — including the post-update status — is available.
-    connect(process, QOverload<int, QProcess::ExitStatus>::of(&QProcess::finished),
-            this, [this, process](int, QProcess::ExitStatus)
-            {
-                // Combine stdout + stderr — the "Server list is outdated" notice
-                // can appear on either stream.
-                const QString combined = QString::fromUtf8(process->readAllStandardOutput())
-                                         + QLatin1Char('\n')
-                                         + QString::fromUtf8(process->readAllStandardError());
-                process->deleteLater();
-
-                // Strip noise lines (same filter used in connectVpn).
-                QStringList lines = combined.split(QLatin1Char('\n'));
-                lines.erase(std::ranges::remove_if(lines, [](const QString& l)
-                {
-                    const QString ll = l.toLower();
-                    return ll.contains(QLatin1String("outdated"))    ||
-                           ll.contains(QLatin1String("updating"))    ||
-                           ll.contains(QLatin1String("this may take"));
-                }).begin(), lines.end());
-
-                // Parse "Key: Value" lines into a map.
-                QMap<QString, QString> fields;
-                for (const QString& line : std::as_const(lines))
-                {
-                    const int colonPos = line.indexOf(QLatin1Char(':'));
-                    if (colonPos < 0) continue;
-                    const QString key   = line.left(colonPos).trimmed().toLower();
-                    const QString value = line.mid(colonPos + 1).trimmed();
-                    if (!key.isEmpty() && !value.isEmpty())
-                        fields.insert(key, value);
-                }
-
-                // "Status: Connected" / "Status: Disconnected"
-                const QString statusVal = fields.value(QStringLiteral("status")).toLower();
-
-                if (statusVal == QStringLiteral("connected"))
-                {
-                    m_state = VpnState::Connected;
-
-                    // "Server: US-NJ#203 in Secaucus, United States"
-                    const QString server = fields.value(QStringLiteral("server"));
-
-                    // Parse city: everything between " in " and the first comma.
-                    // e.g. "US-NJ#203 in Secaucus, United States" → "Secaucus"
-                    QString city;
-                    const int inPos = server.indexOf(QStringLiteral(" in "));
-                    if (inPos >= 0)
-                    {
-                        const QString rest     = server.mid(inPos + 4); // "Secaucus, United States"
-                        const int    commaPos  = rest.indexOf(QLatin1Char(','));
-                        city = (commaPos >= 0 ? rest.left(commaPos) : rest).trimmed();
-                    }
-
-                    // Emit city first so the VPN page can store it before
-                    // updateUi() runs in response to connectionStateChanged.
-                    if (!city.isEmpty())
-                        emit connectionCityKnown(city);
-
-                    const QString info = server.isEmpty()
-                        ? QString()
-                        : QStringLiteral("Connected to %1.").arg(server);
-
-                    emit connectionStateChanged(m_state, info);
-                }
-                else
-                {
-                    m_state = VpnState::Disconnected;
-                    emit connectionStateChanged(m_state, QString());
-                }
-            });
-    process->start(QStringLiteral("protonvpn"), QStringList{QStringLiteral("status")});
-}
-
-
 // ---------------------------------------------------------------------------
-// Settings
+// Settings (file-based — no CLI involved)
 // ---------------------------------------------------------------------------
 
 void VpnManager::fetchSettings()
@@ -553,8 +33,6 @@ void VpnManager::fetchSettings()
     QFile f(kSettingsPath);
     if (!f.open(QIODevice::ReadOnly))
     {
-        // File not found or unreadable — emit empty map so the UI
-        // can still display (all defaults / unknown state).
         emit settingsReady(settings);
         return;
     }
@@ -570,14 +48,11 @@ void VpnManager::fetchSettings()
 
     const QJsonObject root = doc.object();
 
-    // Helper: convert a JSON value to a normalised string ("on"/"off"/value).
     auto boolStr = [](bool b) -> QString
     {
         return b ? QStringLiteral("on") : QStringLiteral("off");
     };
 
-    // ── top-level keys ────────────────────────────────────────────────────
-    // killswitch: 0 = off, 1 = standard
     if (root.contains(QStringLiteral("killswitch")))
     {
         const int ks = root[QStringLiteral("killswitch")].toInt(0);
@@ -593,7 +68,6 @@ void VpnManager::fetchSettings()
         settings.insert(QStringLiteral("anonymous-crash-reports"),
                         boolStr(root[QStringLiteral("anonymous_crash_reports")].toBool()));
 
-    // ── custom_dns ────────────────────────────────────────────────────────
     if (root.contains(QStringLiteral("custom_dns")))
     {
         const QJsonObject dns = root[QStringLiteral("custom_dns")].toObject();
@@ -612,24 +86,19 @@ void VpnManager::fetchSettings()
         }
     }
 
-    // ── features object ───────────────────────────────────────────────────
     if (root.contains(QStringLiteral("features")))
     {
         const QJsonObject feat = root[QStringLiteral("features")].toObject();
 
-        // netshield: 0 = off, 1 = malware-only, 2 = malware-ads-trackers
         if (feat.contains(QStringLiteral("netshield")))
         {
             const int ns = feat[QStringLiteral("netshield")].toInt(0);
             QString nsVal;
             switch (ns)
             {
-            case 1: nsVal = QStringLiteral("malware-only");
-                break;
-            case 2: nsVal = QStringLiteral("malware-ads-trackers");
-                break;
-            default: nsVal = QStringLiteral("off");
-                break;
+            case 1:  nsVal = QStringLiteral("malware-only");         break;
+            case 2:  nsVal = QStringLiteral("malware-ads-trackers"); break;
+            default: nsVal = QStringLiteral("off");                  break;
             }
             settings.insert(QStringLiteral("netshield"), nsVal);
         }
@@ -650,52 +119,18 @@ void VpnManager::fetchSettings()
     emit settingsReady(settings);
 }
 
-void VpnManager::applyConfig(const QString& key, bool enabled)
+bool VpnManager::portForwardingEnabled() const
 {
-    applyConfigValue(key, enabled ? QStringLiteral("on") : QStringLiteral("off"));
-}
-
-void VpnManager::applyConfigValue(const QString& key, const QString& value)
-{
-    // Split value on whitespace so callers can pass e.g. "--dns 1.1.1.1 on"
-    // and have each token become a separate CLI argument.
-    QStringList args{QStringLiteral("config"), QStringLiteral("set"), key};
-    const QStringList valueParts = value.split(QLatin1Char(' '), Qt::SkipEmptyParts);
-    args << valueParts;
-
-    runCommand(args, [this](int, const QString& out, const QString& err)
-    {
-        // Combine stdout and stderr — the CLI prints reconnect notices like
-        // "please establish a new VPN connection for changes to take effect"
-        // to stdout; emit so listeners can act on it.
-        const QString combined = (out + QLatin1Char('\n') + err).trimmed();
-        emit configApplied(combined);
-    });
-}
-
-void VpnManager::fetchCliVersion()
-{
-    // Running `protonvpn` with no args prints the ASCII banner which ends with
-    // the version number on the last banner line, e.g.:
-    //   |_|   |_|  \___/ \__\___/|_| |_|    \_/  |_|   |_| \_| 0.1.7
-    // We scan all output lines for a semver-looking token (digits.digits.digits).
-    runCommand({}, [this](int, const QString& out, const QString& err)
-    {
-        const QString combined = out + QLatin1Char('\n') + err;
-        const QRegularExpression re(QStringLiteral(R"(\b(\d+\.\d+\.\d+)\b)"));
-        // Walk lines in reverse — the version is on the last banner line
-        const QStringList lines = combined.split(QLatin1Char('\n'));
-        for (int i = lines.size() - 1; i >= 0; --i)
-        {
-            const auto match = re.match(lines[i]);
-            if (match.hasMatch())
-            {
-                emit cliVersionReady(match.captured(1));
-                return;
-            }
-        }
-        emit cliVersionReady(QString()); // not found
-    });
+    QFile f(kSettingsPath);
+    if (!f.open(QIODevice::ReadOnly))
+        return false;
+    const QJsonDocument doc = QJsonDocument::fromJson(f.readAll());
+    f.close();
+    if (!doc.isObject())
+        return false;
+    return doc.object()
+               .value(QStringLiteral("features")).toObject()
+               .value(QStringLiteral("port_forwarding")).toBool(false);
 }
 
 // ---------------------------------------------------------------------------
@@ -705,7 +140,7 @@ void VpnManager::fetchCliVersion()
 void VpnManager::startPolling()
 {
     if (m_pollTimer)
-        return; // already running
+        return;
 
     m_pollTimer = new QTimer(this);
     m_pollTimer->setInterval(15'000); // 15 s
@@ -722,144 +157,4 @@ void VpnManager::stopPolling()
         m_pollTimer = nullptr;
     }
     m_pollActive = false;
-}
-
-void VpnManager::pollStatus()
-{
-    if (m_pollActive)
-        return; // previous poll still in flight
-
-    m_pollActive = true;
-
-    auto* process = new QProcess(this);
-    connect(process, QOverload<int, QProcess::ExitStatus>::of(&QProcess::finished),
-            this, [this, process](int, QProcess::ExitStatus)
-            {
-                m_pollActive = false;
-
-                const QString combined =
-                    QString::fromUtf8(process->readAllStandardOutput()) + QLatin1Char('\n') +
-                    QString::fromUtf8(process->readAllStandardError());
-                process->deleteLater();
-
-                // Don't let a background poll override an in-progress connect
-                // or disconnect initiated by the user.
-                if (m_state == VpnState::Connecting || m_state == VpnState::Disconnecting)
-                    return;
-
-                // Strip noise lines
-                QStringList lines = combined.split(QLatin1Char('\n'));
-                lines.erase(std::ranges::remove_if(lines, [](const QString& l)
-                {
-                    const QString ll = l.toLower();
-                    return ll.contains(QLatin1String("outdated"))    ||
-                           ll.contains(QLatin1String("updating"))    ||
-                           ll.contains(QLatin1String("this may take"));
-                }).begin(), lines.end());
-
-                QMap<QString, QString> fields;
-                for (const QString& line : std::as_const(lines))
-                {
-                    const int colonPos = line.indexOf(QLatin1Char(':'));
-                    if (colonPos < 0) continue;
-                    const QString key   = line.left(colonPos).trimmed().toLower();
-                    const QString value = line.mid(colonPos + 1).trimmed();
-                    if (!key.isEmpty() && !value.isEmpty())
-                        fields.insert(key, value);
-                }
-
-                const QString statusVal = fields.value(QStringLiteral("status")).toLower();
-                const VpnState newState = (statusVal == QStringLiteral("connected"))
-                                          ? VpnState::Connected
-                                          : VpnState::Disconnected;
-
-                // Parse server / city / info string regardless of which branch fires below.
-                QString server;
-                QString city;
-                QString info;
-                if (newState == VpnState::Connected)
-                {
-                    server = fields.value(QStringLiteral("server"));
-                    const int inPos = server.indexOf(QStringLiteral(" in "));
-                    if (inPos >= 0)
-                    {
-                        const QString rest    = server.mid(inPos + 4);
-                        const int    commaPos = rest.indexOf(QLatin1Char(','));
-                        city = (commaPos >= 0 ? rest.left(commaPos) : rest).trimmed();
-                    }
-                    info = server.isEmpty()
-                        ? QString()
-                        : QStringLiteral("Connected to %1.").arg(server);
-                }
-
-                // Capture pre-update values so the debug report below can show what changed.
-#ifdef QT_DEBUG
-                const VpnState dbgPrevState  = m_state;
-                const QString  dbgPrevServer = m_connectedServer;
-#endif
-
-                // Also fire when the server/city changed while we stay Connected.
-                // Guard on m_connectedServer being non-empty so the first poll after
-                // an app-initiated connect silently learns the server without causing
-                // a spurious re-emit (which would restart the elapsed timer too soon).
-                if (newState != m_state ||
-                    (newState == VpnState::Connected &&
-                     !m_connectedServer.isEmpty() &&
-                     server != m_connectedServer))
-                {
-                    m_state = newState;
-
-                    if (newState == VpnState::Connected)
-                    {
-                        m_connectedServer = server;
-                        if (!city.isEmpty())
-                        {
-                            emit connectionCityKnown(city);
-                        }
-                        emit connectionStateChanged(m_state, info);
-                    }
-                    else
-                    {
-                        m_connectedServer.clear();
-                        emit connectionStateChanged(m_state, QString());
-                    }
-                }
-                else if (newState == VpnState::Connected && m_connectedServer.isEmpty())
-                {
-                    // Silently record the current server so future polls can diff against it.
-                    m_connectedServer = server;
-                }
-
-#ifdef QT_DEBUG
-                {
-                    auto stateToStr = [](const VpnState s) -> const char*
-                    {
-                        switch (s)
-                        {
-                            case VpnState::Connected:     return "Connected";
-                            case VpnState::Disconnected:  return "Disconnected";
-                            case VpnState::Connecting:    return "Connecting";
-                            case VpnState::Disconnecting: return "Disconnecting";
-                            default:                      return "Error";
-                        }
-                    };
-                    const bool stateChanged  =  newState != dbgPrevState;
-                    const bool serverChanged =  !stateChanged &&
-                                                newState == VpnState::Connected &&
-                                                !dbgPrevServer.isEmpty() &&
-                                                server != dbgPrevServer;
-                    if (stateChanged)
-                    {
-                        qDebug("[Status Polling] State changed:  %s → %s",
-                               stateToStr(dbgPrevState), stateToStr(newState));
-                    }
-                    else if (serverChanged)
-                    {
-                        qDebug("[Status Polling] Server changed: \"%s\" → \"%s\"",
-                               qUtf8Printable(dbgPrevServer), qUtf8Printable(server));
-                    }
-                }
-#endif
-            });
-    process->start(QStringLiteral("protonvpn"), QStringList{QStringLiteral("status")});
 }

--- a/src/vpnmanager.cpp
+++ b/src/vpnmanager.cpp
@@ -255,7 +255,10 @@ void VpnManager::connectVpn(const QString& country, const QString& city)
                 const QString ll = l.toLower();
                 return ll.contains(QLatin1String("outdated")) ||
                     ll.contains(QLatin1String("updating")) ||
-                    ll.contains(QLatin1String("this may take"));
+                    ll.contains(QLatin1String("this may take")) ||
+                    ll.contains(QLatin1String("to get your forwarded port")) ||
+                    ll.contains(QLatin1String("natpmpc")) ||
+                    (ll.startsWith(QLatin1String("guide:")) && ll.contains(QLatin1String("http")));
             }).begin(), lines.end());
             // Remove leading/trailing blank lines left after filtering
             while (!lines.isEmpty() && lines.first().trimmed().isEmpty())

--- a/src/vpnmanager.h
+++ b/src/vpnmanager.h
@@ -45,6 +45,11 @@ public:
     void fetchSettings();
     void applyConfig(const QString& key, bool enabled);
     void applyConfigValue(const QString& key, const QString& value);
+    // Async: fetch the features string for a specific city in a country.
+    // Parses `protonvpn cities list <countryCode>` and calls back with the
+    // features string (e.g. "P2P, Tor") or an empty string if not found.
+    void fetchCityFeatures(const QString& countryCode, const QString& city,
+                           std::function<void(const QString& features)> callback);
     void checkConnectionStatus();
     void fetchCliVersion();
     void fetchAccountType();
@@ -54,6 +59,8 @@ public:
     // Last country / city passed to connectVpn() — empty if connected via CLI.
     QString     lastConnectCountry() const { return m_lastConnectCountry; }
     QString     lastConnectCity()    const { return m_lastConnectCity; }
+    // Reads the port-forwarding setting directly from the settings JSON file.
+    bool        portForwardingEnabled() const;
 
 signals:
     void installedResult(bool installed);
@@ -65,6 +72,9 @@ signals:
     // Emitted (before connectionStateChanged) when a city is parsed from
     // `protonvpn status` output, so the UI can pre-select it in the picker.
     void connectionCityKnown(const QString& city);
+    // Emitted alongside connectionCityKnown with the 2-letter country code
+    // extracted from the connected server name (e.g. "US" from "US-NJ#189").
+    void connectionCountryKnown(const QString& countryCode);
     void countriesReady(const QMap<QString, QString>& countries); // name → code
     void citiesReady(const QString& countryCode, const QList<QPair<QString, QString>>& cities); // (city, features)
     void infoReady(const QMap<QString, QString>& info);


### PR DESCRIPTION
- Change the reconnect dialog primary button text from "Disconnect, Apply && Reconnect" to "Apply && Reconnect" and update the corresponding header comment to match.
- Add UI and logic to display and maintain a forwarded port via natpmpc.
  - Add a hidden "Forwarded Port" row to VpnPage with a bold port label and Copy button; becomes visible when a port is allocated.
  - Implement natpmpc keep-alive loop (startNatPmpLoop, stopNatPmpLoop, runNatPmp) using QProcess and QTimer to refresh mappings every 45s and parse the allocated port with a regex.
  - Show a one-time InfoBanner when natpmpc is not installed and bail out gracefully.
  - Start the natpmpc loop on connect and when config is applied while connected; stop it on disconnect/other non-connected states.
  - Add required members and includes to vpnpage.h and vpnpage.cpp.
  - Remove the Linux-specific port forwarding manual link from settings text.
  - Update vpnmanager filtering to ignore lines mentioning forwarded ports, natpmpc, or guide URLs.
- The natpmpc invocation maps both UDP and TCP (per spec) and parses the UDP response to show the port. The port display is kept current and can be copied to the clipboard.
- Introduce NatPmpManager to manage natpmpc keep-alive (runs every 45s, emits portAcquired/portLost/natpmpcMissing). 
- Add protonvpncli.cpp which moves all protonvpn CLI-related QProcess logic out of vpnmanager.cpp into a dedicated implementation file. 
- Update VpnPage to use NatPmpManager (show/hide port row, copy port from manager, show banner if natpmpc missing, track city features to display port-forwarding notice on startup). 
- Update MainWindow to warn that forwarded port lease lapses when app closes. 
- Update CMakeLists to include new CLI sources and add natpmp manager headers.
- Explicitly state that having both the GTK and Qt GUIs running at the same time is not supported in the README.