### PR TITLE
Enhance error handling and UI for login and VPN processes

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -29,10 +29,10 @@ body:
             I have **searched for duplicate issues** and have not found an existing report for this bug.
           required: true
         - label: >
-            I am running **vanilla Arch Linux or a supported Arch-based distro**. Distros that do not
-            supersede the vanilla Arch repositories are supported (e.g. EndeavourOS ✔). Distros with custom
-            repos that replace or override Arch packages — such as **CachyOS** and **Manjaro** — are **not
-            supported**, as differing package versions can cause unpredictable behavior.
+            **If I installed this app via the AUR**, I am on vanilla Arch Linux or an Arch-based distro
+            whose repositories do not override or supersede the vanilla Arch packages
+            (e.g. EndeavourOS ✔ — **Manjaro** and **CachyOS** ✖). Differing package versions from
+            overriding repos can cause unpredictable behavior.
           required: true
         - label: >
             I understand that **this is a community project with no affiliation with or access to Proton AG's

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -56,6 +56,8 @@ set(SOURCES
         pages/settingspage.cpp
         dialogs/aboutdialog.h
         dialogs/aboutdialog.cpp
+        dialogs/errordetailsdialog.h
+        dialogs/errordetailsdialog.cpp
         resources.qrc
         flags.qrc
 )

--- a/src/cli/protonvpncli.cpp
+++ b/src/cli/protonvpncli.cpp
@@ -145,27 +145,36 @@ void VpnManager::login(const QString& username, const QString& password)
                 const QString combined = state->accumulated.trimmed();
                 delete state;
 
-                if (process == m_signinProcess)
-                    m_signinProcess = nullptr;
+                // If cancelLogin() was called first, m_signinProcess is already
+                // nullptr — don't emit loginFinished for a deliberate cancellation.
+                if (process != m_signinProcess)
+                {
+                    process->deleteLater();
+                    return;
+                }
+                m_signinProcess = nullptr;
                 process->deleteLater();
 
-                const bool ok = exitCode == 0;
+                const bool outputHasError = combined.contains(QStringLiteral("error"), Qt::CaseInsensitive);
+                const bool ok = exitCode == 0 && !outputHasError;
                 QString errorMsg;
                 if (!ok)
                 {
                     const QStringList lines = combined.split(QLatin1Char('\n'), Qt::SkipEmptyParts);
-                    for (const auto& line : std::ranges::reverse_view(lines))
+                    QStringList errorLines;
+                    for (const auto& line : lines)
                     {
                         const QString l = line.trimmed();
                         if (!l.isEmpty()
                             && !l.startsWith(QStringLiteral("Password:"))
-                            && !l.startsWith(QStringLiteral("2FA")))
+                            && !l.startsWith(QStringLiteral("2FA"))
+                            && !l.startsWith(QStringLiteral("Warning:"))
+                            && !l.contains(QStringLiteral(".py:")))
                         {
-                            errorMsg = l;
-                            break;
+                            errorLines.append(l);
                         }
                     }
-                    if (errorMsg.isEmpty()) errorMsg = combined;
+                    errorMsg = errorLines.isEmpty() ? combined : errorLines.join(QLatin1Char('\n'));
                 }
                 else
                 {
@@ -177,6 +186,16 @@ void VpnManager::login(const QString& username, const QString& password)
 
     process->start(QStringLiteral("protonvpn"),
                    QStringList{QStringLiteral("signin"), username});
+}
+
+void VpnManager::cancelLogin()
+{
+    if (m_signinProcess)
+    {
+        m_signinProcess->kill();
+        m_signinProcess->deleteLater();
+        m_signinProcess = nullptr;
+    }
 }
 
 void VpnManager::submit2FA(const QString& token) const

--- a/src/dialogs/aboutdialog.cpp
+++ b/src/dialogs/aboutdialog.cpp
@@ -68,6 +68,9 @@ AboutDialog::AboutDialog(const QString& installedCliVersion, QWidget* parent)
     versionGrid->addWidget(makeKey(QStringLiteral("Tested against CLI:")), 1, 0);
     versionGrid->addWidget(new QLabel(testedVersionStr, versionWidget),    1, 1);
 
+    versionGrid->addWidget(makeKey(QStringLiteral("Qt version:")),         2, 0);
+    versionGrid->addWidget(new QLabel(QStringLiteral(QT_VERSION_STR),      versionWidget), 2, 1);
+
     // Installed CLI version – highlighted only when it differs from tested
     if (!installedCliVersion.isEmpty())
     {
@@ -94,8 +97,8 @@ AboutDialog::AboutDialog(const QString& installedCliVersion, QWidget* parent)
                 QStringLiteral("color: %1; font-weight: bold;").arg(color));
             valLabel->setToolTip(tooltip);
 
-            versionGrid->addWidget(makeKey(QStringLiteral("Installed CLI:")), 2, 0);
-            versionGrid->addWidget(valLabel,                                  2, 1);
+            versionGrid->addWidget(makeKey(QStringLiteral("Installed CLI:")), 3, 0);
+            versionGrid->addWidget(valLabel,                                  3, 1);
         }
     }
 

--- a/src/dialogs/errordetailsdialog.cpp
+++ b/src/dialogs/errordetailsdialog.cpp
@@ -1,0 +1,40 @@
+#include "errordetailsdialog.h"
+
+#include <QVBoxLayout>
+#include <QHBoxLayout>
+#include <QPlainTextEdit>
+#include <QPushButton>
+#include <QFont>
+#include <QGuiApplication>
+#include <QClipboard>
+
+ErrorDetailsDialog::ErrorDetailsDialog(const QString& errorText, QWidget* parent)
+    : QDialog(parent)
+{
+    setWindowTitle(QStringLiteral("Error Details"));
+    setMinimumSize(640, 400);
+    setAttribute(Qt::WA_DeleteOnClose);
+
+    auto* layout = new QVBoxLayout(this);
+    layout->setSpacing(10);
+
+    auto* textEdit = new QPlainTextEdit(this);
+    textEdit->setReadOnly(true);
+    textEdit->setPlainText(errorText);
+    textEdit->setFont(QFont(QStringLiteral("Monospace"), 9));
+    layout->addWidget(textEdit);
+
+    auto* btnRow = new QHBoxLayout();
+    auto* copyBtn = new QPushButton(QStringLiteral("Copy to Clipboard"), this);
+    connect(copyBtn, &QPushButton::clicked, this, [errorText]()
+    {
+        QGuiApplication::clipboard()->setText(errorText);
+    });
+    auto* closeBtn = new QPushButton(QStringLiteral("Close"), this);
+    connect(closeBtn, &QPushButton::clicked, this, &QDialog::accept);
+    btnRow->addWidget(copyBtn);
+    btnRow->addStretch();
+    btnRow->addWidget(closeBtn);
+    layout->addLayout(btnRow);
+}
+

--- a/src/dialogs/errordetailsdialog.h
+++ b/src/dialogs/errordetailsdialog.h
@@ -1,0 +1,17 @@
+#pragma once
+
+#include <QDialog>
+#include <QString>
+
+// ---------------------------------------------------------------------------
+// ErrorDetailsDialog – shows raw VPN/CLI error text with a copy-to-clipboard
+// button.
+// ---------------------------------------------------------------------------
+class ErrorDetailsDialog : public QDialog
+{
+    Q_OBJECT
+
+public:
+    explicit ErrorDetailsDialog(const QString& errorText, QWidget* parent = nullptr);
+};
+

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -105,6 +105,11 @@ MainWindow::MainWindow(QWidget* parent)
         m_loginPage->setError(QString());
         m_manager->submit2FA(token);
     });
+    connect(m_loginPage, &LoginPage::loginCancelRequested, this, [this]()
+    {
+        m_manager->cancelLogin();
+        m_loginPage->reset();
+    });
 
     // VPN page (index 3)
     m_vpnPage = new VpnPage(m_manager);

--- a/src/pages/loginpage.cpp
+++ b/src/pages/loginpage.cpp
@@ -46,13 +46,40 @@ LoginPage::LoginPage(QWidget* parent)
     m_stack->addWidget(m_tfaWidget); // index 1
     cardLayout->addWidget(m_stack);
 
-    // Shared error label below the stack
-    m_errorLabel = new QLabel(card);
-    m_errorLabel->setObjectName(QStringLiteral("errorLabel"));
+    // Shared error section below the stack
+    m_errorContainer = new QWidget(card);
+    m_errorContainer->setVisible(false);
+    auto* errorContainerLayout = new QVBoxLayout(m_errorContainer);
+    errorContainerLayout->setSpacing(6);
+    errorContainerLayout->setContentsMargins(32, 0, 32, 16);
+
+    // Scrollable error label
+    m_errorLabel = new QLabel();
     m_errorLabel->setWordWrap(true);
-    m_errorLabel->setVisible(false);
-    m_errorLabel->setContentsMargins(32, 0, 32, 16);
-    cardLayout->addWidget(m_errorLabel);
+    m_errorLabel->setAlignment(Qt::AlignTop | Qt::AlignLeft);
+    m_errorLabel->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Preferred);
+
+    m_errorScrollArea = new QScrollArea(m_errorContainer);
+    m_errorScrollArea->setWidget(m_errorLabel);
+    m_errorScrollArea->setWidgetResizable(true);
+    m_errorScrollArea->setFixedHeight(100);
+    m_errorScrollArea->setHorizontalScrollBarPolicy(Qt::ScrollBarAlwaysOff);
+    m_errorScrollArea->setVerticalScrollBarPolicy(Qt::ScrollBarAsNeeded);
+    m_errorScrollArea->setObjectName(QStringLiteral("errorLabel"));
+    m_errorScrollArea->viewport()->setStyleSheet(QStringLiteral("background: transparent;"));
+    errorContainerLayout->addWidget(m_errorScrollArea);
+
+    // "View Details" button
+    m_errorDetailsBtn = new QPushButton(QStringLiteral("View Details"), m_errorContainer);
+    m_errorDetailsBtn->setFixedWidth(140);
+    connect(m_errorDetailsBtn, &QPushButton::clicked, this, [this]()
+    {
+        auto* dlg = new ErrorDetailsDialog(m_rawError, this);
+        dlg->exec();
+    });
+    errorContainerLayout->addWidget(m_errorDetailsBtn, 0, Qt::AlignCenter);
+
+    cardLayout->addWidget(m_errorContainer);
 
     m_outerLayout->addWidget(card, 0, Qt::AlignCenter);
 
@@ -179,6 +206,14 @@ void LoginPage::buildTFAWidget()
     });
     connect(m_tfaEdit, &QLineEdit::returnPressed, m_tfaSubmitBtn, &QPushButton::click);
     layout->addWidget(m_tfaSubmitBtn);
+
+    m_tfaCancelBtn = new QPushButton(QStringLiteral("Go Back"), m_tfaWidget);
+    m_tfaCancelBtn->setCursor(Qt::PointingHandCursor);
+    connect(m_tfaCancelBtn, &QPushButton::clicked, this, [this]()
+    {
+        emit loginCancelRequested();
+    });
+    layout->addWidget(m_tfaCancelBtn);
 }
 
 void LoginPage::show2FAPrompt() const
@@ -209,12 +244,16 @@ void LoginPage::setError(const QString& error) const
 {
     if (error.isEmpty())
     {
-        m_errorLabel->setVisible(false);
+        m_errorContainer->setVisible(false);
+        m_errorLabel->clear();
+        m_rawError = QString();
     }
     else
     {
+        m_rawError = error;
         m_errorLabel->setText(error);
-        m_errorLabel->setVisible(true);
+
+        m_errorContainer->setVisible(true);
     }
 }
 
@@ -233,6 +272,7 @@ void LoginPage::setLoading(const bool loading) const
         m_tfaSubmitBtn->setEnabled(!loading);
         m_tfaSubmitBtn->setText(loading ? QStringLiteral("Verifying…") : QStringLiteral("Verify"));
         m_tfaEdit->setEnabled(!loading);
+        m_tfaCancelBtn->setEnabled(!loading);
     }
 }
 

--- a/src/pages/loginpage.h
+++ b/src/pages/loginpage.h
@@ -3,9 +3,11 @@
 #include <QLineEdit>
 #include <QPushButton>
 #include <QLabel>
+#include <QScrollArea>
 #include <QStackedWidget>
 #include <QVBoxLayout>
 #include "../widgets/infobanner.h"
+#include "../dialogs/errordetailsdialog.h"
 
 class LoginPage : public QWidget
 {
@@ -26,6 +28,7 @@ public slots:
 signals:
     void loginRequested(const QString& username, const QString& password);
     void twoFASubmitted(const QString& token);
+    void loginCancelRequested();
 
 private:
     // --- credentials view ---
@@ -39,10 +42,15 @@ private:
     QWidget* m_tfaWidget;
     QLineEdit* m_tfaEdit;
     QPushButton* m_tfaSubmitBtn;
+    QPushButton* m_tfaCancelBtn;
 
     // shared
     QStackedWidget* m_stack;
+    QWidget* m_errorContainer = nullptr;
     QLabel* m_errorLabel;
+    QScrollArea* m_errorScrollArea = nullptr;
+    QPushButton* m_errorDetailsBtn = nullptr;
+    mutable QString m_rawError;
     QVBoxLayout* m_outerLayout = nullptr;
     InfoBanner* m_versionBanner = nullptr;
     InfoBanner* m_prereleaseBanner = nullptr;

--- a/src/pages/vpnpage.cpp
+++ b/src/pages/vpnpage.cpp
@@ -14,9 +14,6 @@
 #include <QPainterPath>
 #include <QSvgRenderer>
 #include <QPropertyAnimation>
-#include <QDialog>
-#include <QPlainTextEdit>
-#include <QFont>
 #include <QGuiApplication>
 #include <QClipboard>
 #include <QCursor>
@@ -1201,6 +1198,9 @@ void VpnPage::updateUi(const VpnState state, const QString& info)
 
     m_errorDetailsBtn->setVisible(false);
     m_signOutHintLabel->setVisible(false);
+    m_infoLabel->setObjectName(QStringLiteral("infoLabel"));
+    m_infoLabel->style()->unpolish(m_infoLabel);
+    m_infoLabel->style()->polish(m_infoLabel);
     m_infoLabel->setTextFormat(Qt::AutoText);
     m_infoLabel->setOpenExternalLinks(false);
 
@@ -1345,6 +1345,9 @@ void VpnPage::updateUi(const VpnState state, const QString& info)
         }
         m_infoLabel->setTextFormat(Qt::RichText);
         m_infoLabel->setOpenExternalLinks(true);
+        m_infoLabel->setObjectName(QStringLiteral("errorLabel"));
+        m_infoLabel->style()->unpolish(m_infoLabel);
+        m_infoLabel->style()->polish(m_infoLabel);
         m_errorDetailsBtn->setVisible(!info.trimmed().isEmpty());
         break;
     }
@@ -1376,33 +1379,7 @@ void VpnPage::stopElapsedTimer() const
 
 void VpnPage::showErrorDetails() const
 {
-    auto* dlg = new QDialog(const_cast<VpnPage*>(this));
-    dlg->setWindowTitle(QStringLiteral("Error Details"));
-    dlg->setMinimumSize(640, 400);
-    dlg->setAttribute(Qt::WA_DeleteOnClose);
-
-    auto* layout = new QVBoxLayout(dlg);
-    layout->setSpacing(10);
-
-    auto* textEdit = new QPlainTextEdit(dlg);
-    textEdit->setReadOnly(true);
-    textEdit->setPlainText(m_rawError);
-    textEdit->setFont(QFont(QStringLiteral("Monospace"), 9));
-    layout->addWidget(textEdit);
-
-    auto* btnRow = new QHBoxLayout();
-    auto* copyBtn = new QPushButton(QStringLiteral("Copy to Clipboard"), dlg);
-    connect(copyBtn, &QPushButton::clicked, dlg, [this]()
-    {
-        QGuiApplication::clipboard()->setText(m_rawError);
-    });
-    auto* closeBtn = new QPushButton(QStringLiteral("Close"), dlg);
-    connect(closeBtn, &QPushButton::clicked, dlg, &QDialog::accept);
-    btnRow->addWidget(copyBtn);
-    btnRow->addStretch();
-    btnRow->addWidget(closeBtn);
-    layout->addLayout(btnRow);
-
+    auto* dlg = new ErrorDetailsDialog(m_rawError, const_cast<VpnPage*>(this));
     dlg->exec();
 }
 

--- a/src/pages/vpnpage.h
+++ b/src/pages/vpnpage.h
@@ -3,13 +3,12 @@
 #include <optional>
 #include <QTimer>
 #include <QPropertyAnimation>
-#include <QDialog>
-#include <QPlainTextEdit>
 #include <QVersionNumber>
 #include "../vpnmanager.h"
 #include "../cli/natpmpmanager.h"
 #include "../widgets/pickerbase.h"
 #include "../widgets/infobanner.h"
+#include "../dialogs/errordetailsdialog.h"
 
 // ---------------------------------------------------------------------------
 // PowerButton

--- a/src/style.qss
+++ b/src/style.qss
@@ -61,7 +61,8 @@ QLabel#fieldLabel {
     font-size: 12px;
 }
 
-QLabel#errorLabel {
+QLabel#errorLabel,
+QAbstractScrollArea#errorLabel {
     color: #ff6b6b;
     background-color: rgba(214, 63, 63, 0.1);
     border: 1px solid #d63f3f;

--- a/src/version.json
+++ b/src/version.json
@@ -1,5 +1,5 @@
 {
-    "app_version": "1.8.2",
+    "app_version": "1.8.3",
     "prerelease": false,
     "cli_version_tested": "1.0.1"
 }

--- a/src/vpnmanager.h
+++ b/src/vpnmanager.h
@@ -34,6 +34,7 @@ public:
     void checkInstalled();
     void checkLoginStatus();
     void login(const QString& username, const QString& password);
+    void cancelLogin();
     void submit2FA(const QString& token) const;
     void signOut();
     void connectVpn(const QString& country = QString(), const QString& city = QString());


### PR DESCRIPTION
- Introduce ErrorDetailsDialog to show raw CLI/VPN error text with copy-to-clipboard support and reuse it from VPN and Login pages.

- Make login error UI scrollable and add a "View Details" button.

- Add a 2FA "Go Back" button and hook it to a new cancelLogin() API.

- Improve CLI signin handling: detect output errors (ignore warnings/.py traces), avoid emitting loginFinished after deliberate cancellation, and implement cancelLogin() to kill the signin process.

- Update styles to target scrollable error areas, add new dialog sources to CMakeLists, and adjust AboutDialog to display Qt version and fix layout indices.

- Bump app version to 1.8.3