### PR TITLE
Add debug logging and ToggleSwitch widget

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -42,6 +42,8 @@ set(SOURCES
         widgets/pickerbase.h
         widgets/svgbanner.h
         widgets/toastnotification.h
+        widgets/toggleswitch.h
+        widgets/toggleswitch.cpp
         pages/notinstalledpage.h
         pages/notinstalledpage.cpp
         pages/loginpage.h

--- a/src/appconfig.cpp
+++ b/src/appconfig.cpp
@@ -1,4 +1,5 @@
 #include "appconfig.h"
+#include "debug.h"
 
 #include <QDir>
 #include <QFile>
@@ -35,6 +36,12 @@ void AppConfig::load()
     m_notifications = obj.value(QStringLiteral("notifications")).toBool(true);
     m_recentConnectionsCount = obj.value(QStringLiteral("recent_connections_count")).toInt(5);
     m_startHidden = obj.value(QStringLiteral("start_hidden")).toBool(false);
+
+    DBG_SETTINGS(QStringLiteral("Config loaded from: ") + kConfigFile);
+    DBG_SETTINGS(QStringLiteral("  auto_connect             = ") + (m_autoConnect ? QStringLiteral("true") : QStringLiteral("false")));
+    DBG_SETTINGS(QStringLiteral("  notifications            = ") + (m_notifications ? QStringLiteral("true") : QStringLiteral("false")));
+    DBG_SETTINGS(QStringLiteral("  recent_connections_count = ") + QString::number(m_recentConnectionsCount));
+    DBG_SETTINGS(QStringLiteral("  start_hidden             = ") + (m_startHidden ? QStringLiteral("true") : QStringLiteral("false")));
 }
 
 bool AppConfig::save() const
@@ -62,6 +69,7 @@ bool AppConfig::autoConnect() const { return m_autoConnect; }
 void AppConfig::setAutoConnect(bool value)
 {
     if (m_autoConnect == value) return;
+    DBG_SETTINGS(QStringLiteral("Setting changed: auto_connect = ") + (value ? QStringLiteral("true") : QStringLiteral("false")));
     m_autoConnect = value;
     (void)save();
 }
@@ -71,6 +79,7 @@ bool AppConfig::notifications() const { return m_notifications; }
 void AppConfig::setNotifications(const bool value)
 {
     if (m_notifications == value) return;
+    DBG_SETTINGS(QStringLiteral("Setting changed: notifications = ") + (value ? QStringLiteral("true") : QStringLiteral("false")));
     m_notifications = value;
     (void)save();
 }
@@ -80,6 +89,7 @@ int AppConfig::recentConnectionsCount() const { return m_recentConnectionsCount;
 void AppConfig::setRecentConnectionsCount(const int value)
 {
     if (m_recentConnectionsCount == value) return;
+    DBG_SETTINGS(QStringLiteral("Setting changed: recent_connections_count = ") + QString::number(qMax(0, value)));
     m_recentConnectionsCount = qMax(0, value);
     (void)save();
 }
@@ -89,6 +99,7 @@ bool AppConfig::startHidden() const { return m_startHidden; }
 void AppConfig::setStartHidden(const bool value)
 {
     if (m_startHidden == value) return;
+    DBG_SETTINGS(QStringLiteral("Setting changed: start_hidden = ") + (value ? QStringLiteral("true") : QStringLiteral("false")));
     m_startHidden = value;
     (void)save();
 }

--- a/src/cli/protonvpncli.cpp
+++ b/src/cli/protonvpncli.cpp
@@ -4,6 +4,7 @@
 // in vpnmanager.cpp.
 
 #include "../vpnmanager.h"
+#include "../debug.h"
 #include "statusmonitor.h"
 
 #include <QProcess>
@@ -19,11 +20,19 @@ void VpnManager::runCommand(const QStringList& args,
                             std::function<void(int, const QString&, const QString&)> callback)
 {
     auto* process = new QProcess(this);
+    const QString cmdLine = QStringLiteral("protonvpn ") + args.join(QLatin1Char(' '));
+    DBG_CLI(QStringLiteral(">>> ") + cmdLine);
     connect(process, &QProcess::finished,
-            this, [process, callback](int exitCode, QProcess::ExitStatus)
+            this, [process, callback, cmdLine](int exitCode, QProcess::ExitStatus)
             {
                 const QString out = QString::fromUtf8(process->readAllStandardOutput()).trimmed();
                 const QString err = QString::fromUtf8(process->readAllStandardError()).trimmed();
+                DBG_CLI(QStringLiteral("<<< ") + cmdLine +
+                        QStringLiteral(" [exit=") + QString::number(exitCode) + QStringLiteral("]"));
+                if (!out.isEmpty())
+                    DBG_CLI(QStringLiteral("    stdout: ") + out);
+                if (!err.isEmpty())
+                    DBG_CLI(QStringLiteral("    stderr: ") + err);
                 callback(exitCode, out, err);
                 process->deleteLater();
             });
@@ -36,6 +45,7 @@ void VpnManager::runCommand(const QStringList& args,
 
 void VpnManager::checkInstalled()
 {
+    DBG_CLI(QStringLiteral("Checking if protonvpn CLI is installed..."));
     auto* process = new QProcess(this);
     connect(process, &QProcess::finished,
             this, [this, process](const int exitCode, QProcess::ExitStatus)
@@ -45,6 +55,7 @@ void VpnManager::checkInstalled()
                 const QString err = QString::fromUtf8(process->readAllStandardError());
                 const bool installed = !out.isEmpty() || !err.isEmpty();
                 process->deleteLater();
+                DBG_CLI(installed ? QStringLiteral("protonvpn CLI found.") : QStringLiteral("protonvpn CLI NOT found."));
                 emit installedResult(installed);
             });
     process->start(QStringLiteral("protonvpn"), QStringList{QStringLiteral("--help")});
@@ -86,6 +97,7 @@ void VpnManager::checkLoginStatus()
 
 void VpnManager::login(const QString& username, const QString& password)
 {
+    DBG_CLI(QStringLiteral("Login attempt for user: ") + username);
     // CLI flow: protonvpn signin <username>
     //   stderr: "Password: "   → write password + '\n' to stdin
     //   stderr: "2FA Token: "  → optional; emit twoFactorRequired()
@@ -121,6 +133,7 @@ void VpnManager::login(const QString& username, const QString& password)
             state->accumulated.contains(QStringLiteral("2FA Token:")))
         {
             state->twoFAEmitted = true;
+            DBG_CLI(QStringLiteral("Two-factor authentication required."));
             emit twoFactorRequired();
         }
     };
@@ -157,6 +170,7 @@ void VpnManager::login(const QString& username, const QString& password)
 
                 const bool outputHasError = combined.contains(QStringLiteral("error"), Qt::CaseInsensitive);
                 const bool ok = exitCode == 0 && !outputHasError;
+                DBG_CLI(ok ? QStringLiteral("Login succeeded.") : QStringLiteral("Login failed (exit=") + QString::number(exitCode) + QStringLiteral(")."));
                 QString errorMsg;
                 if (!ok)
                 {
@@ -206,9 +220,11 @@ void VpnManager::submit2FA(const QString& token) const
 
 void VpnManager::signOut()
 {
+    DBG_CLI(QStringLiteral("Signing out..."));
     stopStatusMonitor();
     runCommand({QStringLiteral("signout")}, [this](int exitCode, const QString&, const QString&)
     {
+        DBG_CLI(exitCode == 0 ? QStringLiteral("Sign-out succeeded.") : QStringLiteral("Sign-out failed (exit=") + QString::number(exitCode) + QStringLiteral(")."));
         m_state = VpnState::Disconnected;
         emit signOutFinished(exitCode == 0);
     });
@@ -220,6 +236,8 @@ void VpnManager::signOut()
 
 void VpnManager::connectVpn(const QString& country, const QString& city)
 {
+    DBG_CLI(QStringLiteral("Connecting to VPN — country: '") + (country.isEmpty() ? QStringLiteral("(fastest)") : country) +
+            QStringLiteral("'  city: '") + (city.isEmpty() ? QStringLiteral("(any)") : city) + QStringLiteral("'"));
     m_lastConnectCountry = country;
     m_lastConnectCity    = city;
     m_connectedServer.clear();
@@ -237,6 +255,7 @@ void VpnManager::connectVpn(const QString& country, const QString& city)
     {
         if (exitCode == 0)
         {
+            DBG_CLI(QStringLiteral("VPN connected successfully."));
             m_state = VpnState::Connected;
             // Strip noise / port-forwarding guide lines from CLI output.
             QStringList lines = out.split(QLatin1Char('\n'));
@@ -256,6 +275,7 @@ void VpnManager::connectVpn(const QString& country, const QString& city)
         }
         else
         {
+            DBG_CLI(QStringLiteral("VPN connection failed (exit=") + QString::number(exitCode) + QStringLiteral("): ") + (err.isEmpty() ? out : err));
             m_state = VpnState::Error;
             emit connectionStateChanged(m_state, err.isEmpty() ? out : err);
             emit errorOccurred(err.isEmpty() ? out : err);
@@ -265,6 +285,7 @@ void VpnManager::connectVpn(const QString& country, const QString& city)
 
 void VpnManager::disconnectVpn()
 {
+    DBG_CLI(QStringLiteral("Disconnecting VPN..."));
     m_state = VpnState::Disconnecting;
     emit connectionStateChanged(m_state, QString());
 
@@ -272,11 +293,13 @@ void VpnManager::disconnectVpn()
     {
         if (exitCode == 0)
         {
+            DBG_CLI(QStringLiteral("VPN disconnected successfully."));
             m_state = VpnState::Disconnected;
             emit connectionStateChanged(m_state, out);
         }
         else
         {
+            DBG_CLI(QStringLiteral("VPN disconnect failed (exit=") + QString::number(exitCode) + QStringLiteral("): ") + (err.isEmpty() ? out : err));
             m_state = VpnState::Error;
             emit connectionStateChanged(m_state, err.isEmpty() ? out : err);
             emit errorOccurred(err.isEmpty() ? out : err);
@@ -475,6 +498,7 @@ void VpnManager::applyConfig(const QString& key, bool enabled)
 
 void VpnManager::applyConfigValue(const QString& key, const QString& value)
 {
+    DBG_CLI(QStringLiteral("Applying CLI config: ") + key + QStringLiteral(" = ") + value);
     QStringList args{QStringLiteral("config"), QStringLiteral("set"), key};
     args << value.split(QLatin1Char(' '), Qt::SkipEmptyParts);
 

--- a/src/debug.h
+++ b/src/debug.h
@@ -1,0 +1,28 @@
+#pragma once
+
+// debug.h — Lightweight diagnostic logging helpers.
+// Prints to stdout when the app is started from a terminal.
+// All output is prefixed with a tag for easy grepping.
+
+#include <QString>
+#include <QDateTime>
+#include <cstdio>
+
+// ── Core print function ──────────────────────────────────────────────────────
+
+inline void dbgPrint(const char* tag, const QString& message)
+{
+    const QString timestamp = QDateTime::currentDateTime().toString(QStringLiteral("hh:mm:ss.zzz"));
+    fprintf(stdout, "[%s] [%s] %s\n",
+            qPrintable(timestamp),
+            tag,
+            qPrintable(message));
+    fflush(stdout);
+}
+
+// ── Convenience macros ───────────────────────────────────────────────────────
+
+#define DBG_APP(msg)      dbgPrint("APP     ", (msg))
+#define DBG_CLI(msg)      dbgPrint("CLI     ", (msg))
+#define DBG_SETTINGS(msg) dbgPrint("SETTINGS", (msg))
+

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -9,6 +9,10 @@
 #include <QJsonObject>
 #include "mainwindow.h"
 #include "appconfig.h"
+#include "debug.h"
+#include <QSysInfo>
+#include <QLocale>
+#include <QStandardPaths>
 
 int main(int argc, char* argv[])
 {
@@ -17,7 +21,8 @@ int main(int argc, char* argv[])
     QApplication::setApplicationDisplayName(QStringLiteral("ProtonVPN"));
 
     // Read version from the embedded version.json so there is a single source of truth.
-    QString appVersion = QStringLiteral("1.0.0");
+    QString appVersion = QStringLiteral("unknown");
+    QString cliVersionTested = QStringLiteral("unknown");
     QFile vf(QStringLiteral(":/version.json"));
     if (vf.open(QIODevice::ReadOnly))
     {
@@ -25,8 +30,23 @@ int main(int argc, char* argv[])
         vf.close();
         if (obj.contains(QStringLiteral("app_version")))
             appVersion = obj[QStringLiteral("app_version")].toString();
+        if (obj.contains(QStringLiteral("cli_version_tested")))
+            cliVersionTested = obj[QStringLiteral("cli_version_tested")].toString();
     }
     QApplication::setApplicationVersion(appVersion);
+
+    // ── Startup diagnostics ──────────────────────────────────────────────────
+    DBG_APP(QStringLiteral("=== ProtonVPN Qt App starting ==="));
+    DBG_APP(QStringLiteral("App version    : ") + appVersion);
+    DBG_APP(QStringLiteral("CLI tested for : ") + cliVersionTested);
+    DBG_APP(QStringLiteral("Qt version     : ") + QString::fromLatin1(qVersion()));
+    DBG_APP(QStringLiteral("OS             : ") + QSysInfo::prettyProductName());
+    DBG_APP(QStringLiteral("Kernel         : ") + QSysInfo::kernelVersion());
+    DBG_APP(QStringLiteral("CPU arch       : ") + QSysInfo::currentCpuArchitecture());
+    DBG_APP(QStringLiteral("Locale         : ") + QLocale::system().name());
+    DBG_APP(QStringLiteral("Config dir     : ") +
+            QStandardPaths::writableLocation(QStandardPaths::AppConfigLocation));
+    DBG_APP(QStringLiteral("================================="));
 
     // Single-instance guard — prevent multiple copies running at the same time.
     const QString lockPath = QDir::tempPath() + QStringLiteral("/proton-vpn-qt-app.lock");
@@ -34,6 +54,11 @@ int main(int argc, char* argv[])
     lockFile.setStaleLockTime(0); // never treat a lock as stale
     if (!lockFile.tryLock(100))
     {
+        qint64 pid = 0; QString hostname, appname;
+        lockFile.getLockInfo(&pid, &hostname, &appname);
+        DBG_APP(QStringLiteral("Another instance of ProtonVPN is already running (PID: ") +
+                (pid > 0 ? QString::number(pid) : QStringLiteral("unknown")) +
+                QStringLiteral("). Exiting."));
         QMessageBox::warning(
             nullptr,
             QStringLiteral("Already Running"),

--- a/src/pages/settingspage.cpp
+++ b/src/pages/settingspage.cpp
@@ -2,6 +2,7 @@
 #include "../appconfig.h"
 #include "../connectionhistory.h"
 #include "../uihelpers.h"
+#include "../widgets/toggleswitch.h"
 
 #include <QSpinBox>
 #include <QVBoxLayout>
@@ -9,16 +10,12 @@
 #include <QScrollArea>
 #include "../widgets/numberspinner.h"
 #include "../widgets/toastnotification.h"
-#include <QPropertyAnimation>
-#include <QMouseEvent>
 #include <QGraphicsOpacityEffect>
 #include <QDialogButtonBox> // ignore unused include warning for QDialogButtonBox
 #include <QTextBrowser>
 #include <QMessageBox>
 #include <QStyle>
 #include <QFontDatabase>
-#include <QSvgRenderer>
-#include <QPainter>
 #include <QClipboard>
 #include <QApplication>
 #include <QDir>
@@ -34,75 +31,6 @@
 #include <QDebug>
 #include <optional>
 
-// ============================================================
-// ToggleSwitch
-// ============================================================
-
-ToggleSwitch::ToggleSwitch(QWidget* parent) : QWidget(parent)
-{
-    setFixedSize(ToggleSwitch::sizeHint());
-    setCursor(Qt::PointingHandCursor);
-    m_anim = new QPropertyAnimation(this, "knobPos", this);
-    m_anim->setDuration(150);
-    m_anim->setEasingCurve(QEasingCurve::InOutQuad);
-}
-
-void ToggleSwitch::setOn(const bool on, const bool animate)
-{
-    if (m_on == on) return;
-    m_on = on;
-
-    m_anim->stop();
-
-    if (animate)
-    {
-        m_anim->setStartValue(m_knobPos);
-        m_anim->setEndValue(on ? 1.0 : 0.0);
-        m_anim->start();
-    }
-    else
-    {
-        m_knobPos = on ? 1.0 : 0.0;
-        update();
-    }
-}
-
-void ToggleSwitch::paintEvent(QPaintEvent*)
-{
-    QPainter p(this);
-    p.setRenderHint(QPainter::Antialiasing);
-    const bool enabled = isEnabled();
-    const int w = width(), h = height(), r = h / 2;
-    if (enabled)
-    {
-        constexpr QColor trackOn(0x6d, 0x4a, 0xff), trackOff(0x55, 0x55, 0x66);
-        QColor track;
-        track.setRed(static_cast<int>(trackOff.red() + (trackOn.red() - trackOff.red()) * m_knobPos));
-        track.setGreen(static_cast<int>(trackOff.green() + (trackOn.green() - trackOff.green()) * m_knobPos));
-        track.setBlue(static_cast<int>(trackOff.blue() + (trackOn.blue() - trackOff.blue()) * m_knobPos));
-        p.setBrush(track);
-    }
-    else
-    {
-        p.setBrush(QColor(0x3a, 0x3a, 0x44));
-    }
-    p.setPen(Qt::NoPen);
-    p.drawRoundedRect(0, 0, w, h, r, r);
-    const int knobD = h - 4, knobMin = 2, knobMax = w - knobD - 2;
-    const int knobX = static_cast<int>(knobMin + (knobMax - knobMin) * m_knobPos);
-    p.setBrush(enabled ? Qt::white : QColor(0x66, 0x66, 0x77));
-    p.drawEllipse(knobX, 2, knobD, knobD);
-}
-
-void ToggleSwitch::mousePressEvent(QMouseEvent* e)
-{
-    if (e->button() == Qt::LeftButton)
-    {
-        setOn(!m_on);
-        emit toggled(m_on);
-    }
-    QWidget::mousePressEvent(e);
-}
 
 // ============================================================
 // SettingsPage helpers

--- a/src/pages/settingspage.h
+++ b/src/pages/settingspage.h
@@ -10,43 +10,7 @@
 #include "../vpnmanager.h"
 #include "../cli/natpmpmanager.h"
 #include "../dialogs/aboutdialog.h"
-
-// ---------------------------------------------------------------------------
-// ToggleSwitch – animated on/off switch
-// ---------------------------------------------------------------------------
-class ToggleSwitch : public QWidget
-{
-    Q_OBJECT
-    Q_PROPERTY(qreal knobPos READ knobPos WRITE setKnobPos)
-
-public:
-    explicit ToggleSwitch(QWidget* parent = nullptr);
-
-    [[nodiscard]] bool isOn() const { return m_on; }
-    void setOn(bool on, bool animate = true);
-
-    [[nodiscard]] qreal knobPos() const { return m_knobPos; }
-
-    void setKnobPos(const qreal v)
-    {
-        m_knobPos = v;
-        update();
-    }
-
-    [[nodiscard]] QSize sizeHint() const override { return {44, 24}; }
-
-signals:
-    void toggled(bool on);
-
-protected:
-    void paintEvent(QPaintEvent*) override;
-    void mousePressEvent(QMouseEvent*) override;
-
-private:
-    bool m_on = false;
-    qreal m_knobPos = 0.0;
-    class QPropertyAnimation* m_anim;
-};
+#include "../widgets/toggleswitch.h"
 
 // ---------------------------------------------------------------------------
 // SettingsPage

--- a/src/version.json
+++ b/src/version.json
@@ -1,5 +1,5 @@
 {
-    "app_version": "1.8.3",
+    "app_version": "1.8.4",
     "prerelease": false,
     "cli_version_tested": "1.0.1"
 }

--- a/src/widgets/toggleswitch.cpp
+++ b/src/widgets/toggleswitch.cpp
@@ -1,0 +1,76 @@
+#include "toggleswitch.h"
+
+#include <QPropertyAnimation>
+#include <QMouseEvent>
+#include <QPainter>
+
+// ============================================================
+// ToggleSwitch
+// ============================================================
+
+ToggleSwitch::ToggleSwitch(QWidget* parent) : QWidget(parent)
+{
+    setFixedSize(ToggleSwitch::sizeHint());
+    setCursor(Qt::PointingHandCursor);
+    m_anim = new QPropertyAnimation(this, "knobPos", this);
+    m_anim->setDuration(150);
+    m_anim->setEasingCurve(QEasingCurve::InOutQuad);
+}
+
+void ToggleSwitch::setOn(const bool on, const bool animate)
+{
+    if (m_on == on) return;
+    m_on = on;
+
+    m_anim->stop();
+
+    if (animate)
+    {
+        m_anim->setStartValue(m_knobPos);
+        m_anim->setEndValue(on ? 1.0 : 0.0);
+        m_anim->start();
+    }
+    else
+    {
+        m_knobPos = on ? 1.0 : 0.0;
+        update();
+    }
+}
+
+void ToggleSwitch::paintEvent(QPaintEvent*)
+{
+    QPainter p(this);
+    p.setRenderHint(QPainter::Antialiasing);
+    const bool enabled = isEnabled();
+    const int w = width(), h = height(), r = h / 2;
+    if (enabled)
+    {
+        constexpr QColor trackOn(0x6d, 0x4a, 0xff), trackOff(0x55, 0x55, 0x66);
+        QColor track;
+        track.setRed(static_cast<int>(trackOff.red() + (trackOn.red() - trackOff.red()) * m_knobPos));
+        track.setGreen(static_cast<int>(trackOff.green() + (trackOn.green() - trackOff.green()) * m_knobPos));
+        track.setBlue(static_cast<int>(trackOff.blue() + (trackOn.blue() - trackOff.blue()) * m_knobPos));
+        p.setBrush(track);
+    }
+    else
+    {
+        p.setBrush(QColor(0x3a, 0x3a, 0x44));
+    }
+    p.setPen(Qt::NoPen);
+    p.drawRoundedRect(0, 0, w, h, r, r);
+    const int knobD = h - 4, knobMin = 2, knobMax = w - knobD - 2;
+    const int knobX = static_cast<int>(knobMin + (knobMax - knobMin) * m_knobPos);
+    p.setBrush(enabled ? Qt::white : QColor(0x66, 0x66, 0x77));
+    p.drawEllipse(knobX, 2, knobD, knobD);
+}
+
+void ToggleSwitch::mousePressEvent(QMouseEvent* e)
+{
+    if (e->button() == Qt::LeftButton)
+    {
+        setOn(!m_on);
+        emit toggled(m_on);
+    }
+    QWidget::mousePressEvent(e);
+}
+

--- a/src/widgets/toggleswitch.h
+++ b/src/widgets/toggleswitch.h
@@ -1,0 +1,41 @@
+#pragma once
+
+#include <QWidget>
+
+// ---------------------------------------------------------------------------
+// ToggleSwitch – animated on/off switch
+// ---------------------------------------------------------------------------
+class ToggleSwitch : public QWidget
+{
+    Q_OBJECT
+    Q_PROPERTY(qreal knobPos READ knobPos WRITE setKnobPos)
+
+public:
+    explicit ToggleSwitch(QWidget* parent = nullptr);
+
+    [[nodiscard]] bool isOn() const { return m_on; }
+    void setOn(bool on, bool animate = true);
+
+    [[nodiscard]] qreal knobPos() const { return m_knobPos; }
+
+    void setKnobPos(const qreal v)
+    {
+        m_knobPos = v;
+        update();
+    }
+
+    [[nodiscard]] QSize sizeHint() const override { return {44, 24}; }
+
+signals:
+    void toggled(bool on);
+
+protected:
+    void paintEvent(QPaintEvent*) override;
+    void mousePressEvent(QMouseEvent*) override;
+
+private:
+    bool m_on = false;
+    qreal m_knobPos = 0.0;
+    class QPropertyAnimation* m_anim;
+};
+


### PR DESCRIPTION
- Introduce diagnostic logging (src/debug.h) and sprinkle DBG_* calls across app init, AppConfig and VpnManager to improve runtime visibility (startup info, CLI commands, connection/login events, and settings changes).

- Extract ToggleSwitch out of SettingsPage into reusable widget files (src/widgets/toggleswitch.h/.cpp) and update SettingsPage/CMakeLists to use the new widget.

- Bump app version to 1.8.4.