### PR TITLE
Add Flatpak packaging and runtime support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,7 @@ on:
   pull_request:
     branches:
       - main
+  workflow_dispatch:
 
 jobs:
   build:
@@ -31,3 +32,65 @@ jobs:
       - name: Confirm binary exists
         run: test -f build/proton_vpn_qt
 
+  build-flatpak:
+    name: Build Flatpak (Ubuntu)
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install Flatpak tools
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y flatpak flatpak-builder
+
+      - name: Add flathub remote
+        run: |
+          flatpak remote-add --user --if-not-exists flathub \
+            https://dl.flathub.org/repo/flathub.flatpakrepo
+
+      - name: Resolve latest KDE runtime version
+        id: kde
+        run: |
+          latest=$(flatpak remote-ls --user --runtime --columns=ref flathub \
+            | grep "^runtime/org.kde.Platform/x86_64/" \
+            | sed 's|runtime/org.kde.Platform/x86_64/||' \
+            | grep -E '^[0-9]+\.[0-9]+$' \
+            | sort -V \
+            | tail -1)
+          if [[ -z "$latest" ]]; then
+            echo "::error::Could not resolve the latest org.kde.Platform version from Flathub."
+            exit 1
+          fi
+          echo "Resolved KDE runtime version: $latest"
+          echo "version=$latest" >> "$GITHUB_OUTPUT"
+
+      - name: Patch manifest runtime-version
+        run: |
+          sed -i "s/^runtime-version:.*/runtime-version: '${{ steps.kde.outputs.version }}'/" \
+            io.github.wheat32.ProtonVPNQt.yml
+
+      - name: Install KDE runtime and SDK
+        run: |
+          flatpak install --user --noninteractive flathub \
+            org.kde.Platform/x86_64/${{ steps.kde.outputs.version }} \
+            org.kde.Sdk/x86_64/${{ steps.kde.outputs.version }}
+
+      - name: Build Flatpak
+        run: |
+          flatpak-builder \
+            --force-clean \
+            --repo=.flatpak-repo \
+            .flatpak-build \
+            io.github.wheat32.ProtonVPNQt.yml
+
+      - name: Export bundle
+        run: |
+          flatpak build-bundle \
+            .flatpak-repo \
+            io.github.wheat32.ProtonVPNQt.flatpak \
+            io.github.wheat32.ProtonVPNQt
+
+      - name: Confirm bundle exists
+        run: test -f io.github.wheat32.ProtonVPNQt.flatpak

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,8 +9,8 @@ permissions:
   contents: write   # needed to create releases and upload assets
 
 jobs:
-  build-and-release:
-    name: Build & Release (Ubuntu)
+  build-native:
+    name: Build Native (Ubuntu)
     runs-on: ubuntu-latest
 
     steps:
@@ -31,11 +31,95 @@ jobs:
       - name: Build
         run: cmake --build build --parallel
 
-      - name: Package
+      - name: Package tarball
         run: |
           mkdir -p dist
           cp build/proton_vpn_qt dist/
           tar -czf proton-vpn-qt-app-linux-x86_64.tar.gz -C dist proton_vpn_qt
+
+      - name: Upload tarball artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: native-tarball
+          path: proton-vpn-qt-app-linux-x86_64.tar.gz
+
+  build-flatpak:
+    name: Build Flatpak (Ubuntu)
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install Flatpak tools
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y flatpak flatpak-builder
+
+      - name: Add flathub remote
+        run: |
+          flatpak remote-add --user --if-not-exists flathub \
+            https://dl.flathub.org/repo/flathub.flatpakrepo
+
+      - name: Resolve latest KDE runtime version
+        id: kde
+        run: |
+          latest=$(flatpak remote-ls --user --runtime --columns=ref flathub \
+            | grep "^runtime/org.kde.Platform/x86_64/" \
+            | sed 's|runtime/org.kde.Platform/x86_64/||' \
+            | grep -E '^[0-9]+\.[0-9]+$' \
+            | sort -V \
+            | tail -1)
+          if [[ -z "$latest" ]]; then
+            echo "::error::Could not resolve the latest org.kde.Platform version from Flathub."
+            exit 1
+          fi
+          echo "Resolved KDE runtime version: $latest"
+          echo "version=$latest" >> "$GITHUB_OUTPUT"
+
+      - name: Patch manifest runtime-version
+        run: |
+          sed -i "s/^runtime-version:.*/runtime-version: '${{ steps.kde.outputs.version }}'/" \
+            io.github.wheat32.ProtonVPNQt.yml
+
+      - name: Install KDE runtime and SDK
+        run: |
+          flatpak install --user --noninteractive flathub \
+            org.kde.Platform/x86_64/${{ steps.kde.outputs.version }} \
+            org.kde.Sdk/x86_64/${{ steps.kde.outputs.version }}
+
+      - name: Build Flatpak
+        run: |
+          flatpak-builder \
+            --force-clean \
+            --repo=.flatpak-repo \
+            .flatpak-build \
+            io.github.wheat32.ProtonVPNQt.yml
+
+      - name: Export bundle
+        run: |
+          flatpak build-bundle \
+            .flatpak-repo \
+            io.github.wheat32.ProtonVPNQt.flatpak \
+            io.github.wheat32.ProtonVPNQt
+
+      - name: Upload Flatpak artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: flatpak-bundle
+          path: io.github.wheat32.ProtonVPNQt.flatpak
+
+  release:
+    name: Create GitHub Release
+    runs-on: ubuntu-latest
+    needs: [build-native, build-flatpak]
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install jq
+        run: sudo apt-get install -y jq
 
       - name: Read version
         id: tag
@@ -44,6 +128,16 @@ jobs:
           echo "VERSION=$VERSION" >> "$GITHUB_OUTPUT"
           echo "TAG=v$VERSION" >> "$GITHUB_OUTPUT"
           echo "NAME=v$VERSION" >> "$GITHUB_OUTPUT"
+
+      - name: Download native tarball
+        uses: actions/download-artifact@v4
+        with:
+          name: native-tarball
+
+      - name: Download Flatpak bundle
+        uses: actions/download-artifact@v4
+        with:
+          name: flatpak-bundle
 
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v2
@@ -55,14 +149,31 @@ jobs:
 
             **Commit message:** ${{ github.event.head_commit.message }}
 
-            ## Installation
-            Download `proton-vpn-qt-app-linux-x86_64.tar.gz`, extract it, and run the `proton_vpn_qt` binary.
+            ## Downloads
 
+            | File | Description |
+            |------|-------------|
+            | `proton-vpn-qt-app-linux-x86_64.tar.gz` | Native binary (extract and run) |
+            | `io.github.wheat32.ProtonVPNQt.flatpak` | Flatpak bundle (see below) |
+
+            ### Native binary
             ```bash
             tar -xzf proton-vpn-qt-app-linux-x86_64.tar.gz
             ./proton_vpn_qt
             ```
 
+            ### Flatpak bundle
+            The Flatpak calls the host's `protonvpn` CLI via `flatpak-spawn --host`, so the
+            [Proton VPN Linux CLI](https://protonvpn.com/support/linux-vpn-tool/) must be
+            installed on your host system.
+
+            ```bash
+            flatpak install io.github.wheat32.ProtonVPNQt.flatpak
+            flatpak run io.github.wheat32.ProtonVPNQt
+            ```
+
             > This is a community build. See the [README](https://github.com/${{ github.repository }}/blob/main/README.md) for requirements and usage.
-          files: proton-vpn-qt-app-linux-x86_64.tar.gz
+          files: |
+            proton-vpn-qt-app-linux-x86_64.tar.gz
+            io.github.wheat32.ProtonVPNQt.flatpak
           make_latest: true

--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,11 @@ build/
 
 # Jetbrains
 .idea/
+
+# Flatpak Building
+.flatpak-repo/
+.flatpak-build/
+.flatpak-builder/
+
+# Binaries
+dist/

--- a/build-flatpak.sh
+++ b/build-flatpak.sh
@@ -1,0 +1,104 @@
+#!/usr/bin/env bash
+# build-flatpak.sh
+# Sets up the Flatpak builder environment and builds the Flatpak bundle.
+#
+# Usage:
+#   ./build-flatpak.sh              # build only
+#   ./build-flatpak.sh --install    # build and install for the current user
+#
+# Requirements (installed automatically if missing when run with sudo/apt):
+#   flatpak, flatpak-builder
+#
+# The output bundle is written to:
+#   dist/io.github.wheat32.ProtonVPNQt.flatpak
+
+set -euo pipefail
+
+MANIFEST="io.github.wheat32.ProtonVPNQt.yml"
+APP_ID="io.github.wheat32.ProtonVPNQt"
+BUILD_DIR=".flatpak-build"
+REPO_DIR=".flatpak-repo"
+BUNDLE="dist/${APP_ID}.flatpak"
+RUNTIME="org.kde.Platform"
+RUNTIME_VERSION=""   # resolved dynamically from Flathub at runtime
+
+# ── Resolve latest KDE runtime version from Flathub ──────────────────────────
+resolve_runtime_version() {
+    info "Querying Flathub for the latest ${RUNTIME} version..."
+    local latest
+    latest=$(flatpak remote-ls --user --runtime --columns=ref flathub 2>/dev/null \
+        | grep "^runtime/${RUNTIME}/x86_64/" \
+        | sed "s|runtime/${RUNTIME}/x86_64/||" \
+        | grep -E '^[0-9]+\.[0-9]+$' \
+        | sort -V \
+        | tail -1)
+
+    if [[ -z "$latest" ]]; then
+        die "Could not resolve the latest ${RUNTIME} version from Flathub. Are you online?"
+    fi
+
+    RUNTIME_VERSION="$latest"
+    info "Using KDE runtime version: ${RUNTIME_VERSION}"
+}
+
+# ── Color helpers ────────────────────────────────────────────────────────────
+GREEN='\033[0;32m'; YELLOW='\033[1;33m'; RED='\033[0;31m'; NC='\033[0m'
+info()    { echo -e "${GREEN}[build-flatpak]${NC} $*"; }
+warn()    { echo -e "${YELLOW}[build-flatpak]${NC} $*"; }
+die()     { echo -e "${RED}[build-flatpak] ERROR:${NC} $*" >&2; exit 1; }
+
+# ── Sanity checks ─────────────────────────────────────────────────────────────
+command -v flatpak         >/dev/null 2>&1 || die "flatpak is not installed. Install it with: sudo apt install flatpak"
+command -v flatpak-builder >/dev/null 2>&1 || die "flatpak-builder is not installed. Install it with: sudo apt install flatpak-builder"
+
+[[ -f "$MANIFEST" ]] || die "Manifest '$MANIFEST' not found. Run this script from the repository root."
+
+# ── Ensure the KDE runtime + SDK are available ───────────────────────────
+info "Checking for Flatpak remote 'flathub'..."
+if ! flatpak remote-list --user | grep -q flathub; then
+    info "Adding flathub remote (user)..."
+    flatpak remote-add --user --if-not-exists flathub \
+        https://dl.flathub.org/repo/flathub.flatpakrepo
+fi
+
+resolve_runtime_version
+
+# ── Patch manifest with resolved runtime version ──────────────────────────────
+info "Patching manifest: runtime-version -> ${RUNTIME_VERSION}..."
+sed -i "s/^runtime-version:.*/runtime-version: '${RUNTIME_VERSION}'/" "$MANIFEST"
+
+for component in "${RUNTIME}/${RUNTIME_VERSION}" "${RUNTIME%Platform}Sdk/${RUNTIME_VERSION}"; do
+    ref="${component%%/*}/x86_64/${component#*/}"
+    if ! flatpak info --user "$ref" >/dev/null 2>&1; then
+        info "Installing $ref from flathub..."
+        flatpak install --user --noninteractive flathub "$ref" || \
+            warn "Could not auto-install $ref — you may need to run: flatpak install flathub $ref"
+    fi
+done
+
+# ── Build ─────────────────────────────────────────────────────────────────────
+info "Building Flatpak (this may take a while on first run)..."
+mkdir -p dist
+
+flatpak-builder \
+    --force-clean \
+    --repo="$REPO_DIR" \
+    "$BUILD_DIR" \
+    "$MANIFEST"
+
+# ── Export bundle ─────────────────────────────────────────────────────────────
+info "Exporting bundle to $BUNDLE..."
+flatpak build-bundle \
+    "$REPO_DIR" \
+    "$BUNDLE" \
+    "$APP_ID"
+
+info "Build complete: $BUNDLE"
+
+# ── Optional install ──────────────────────────────────────────────────────────
+if [[ "${1:-}" == "--install" ]]; then
+    info "Installing $APP_ID for current user..."
+    flatpak install --user --noninteractive "$BUNDLE"
+    info "Run with: flatpak run $APP_ID"
+fi
+

--- a/io.github.wheat32.ProtonVPNQt.yml
+++ b/io.github.wheat32.ProtonVPNQt.yml
@@ -1,0 +1,48 @@
+app-id: io.github.wheat32.ProtonVPNQt
+runtime: org.kde.Platform
+runtime-version: '6.10'
+sdk: org.kde.Sdk
+command: proton_vpn_qt
+finish-args:
+  # Display
+  - --share=ipc
+  - --socket=fallback-x11
+  - --socket=wayland
+  # Network access (for VPN status polling, API calls)
+  - --share=network
+  # Talk to the host D-Bus session bus (for system tray, notifications)
+  - --socket=session-bus
+  # Allow talking to the host system bus (NetworkManager, systemd, etc.)
+  - --socket=system-bus
+  # Allow flatpak-spawn to call the host protonvpn CLI
+  - --talk-name=org.freedesktop.Flatpak
+  # Read-only access to the ProtonVPN settings file written by the host CLI.
+  # Without this, fetchSettings() cannot read ~/.config/Proton/VPN/settings.json
+  # and all VPN settings toggles will appear as OFF.
+  - --filesystem=~/.config/Proton:ro
+  # Allow writing the systemd user service file for the "Launch on Startup" feature.
+  - --filesystem=~/.config/systemd/user
+
+modules:
+  - name: proton_vpn_qt
+    buildsystem: cmake-ninja
+    builddir: true
+    config-opts:
+      - -DCMAKE_BUILD_TYPE=Release
+    subdir: src
+    post-install:
+      # Rename the icon to match the Flatpak app-id so the launcher can find it
+      - mv /app/share/icons/hicolor/scalable/apps/proton-vpn-qt-app.svg
+          /app/share/icons/hicolor/scalable/apps/io.github.wheat32.ProtonVPNQt.svg
+      # Patch the Icon= and Exec= fields in the installed .desktop file
+      - sed -i 's/^Icon=.*/Icon=io.github.wheat32.ProtonVPNQt/'
+          /app/share/applications/proton-vpn-qt-app.desktop
+      - sed -i 's/^Exec=.*/Exec=proton_vpn_qt/'
+          /app/share/applications/proton-vpn-qt-app.desktop
+      # Rename the .desktop file itself to the app-id (required by Flatpak)
+      - mv /app/share/applications/proton-vpn-qt-app.desktop
+          /app/share/applications/io.github.wheat32.ProtonVPNQt.desktop
+    sources:
+      - type: dir
+        path: .
+

--- a/proton-vpn-qt-app.desktop
+++ b/proton-vpn-qt-app.desktop
@@ -1,0 +1,11 @@
+[Desktop Entry]
+Name=Proton VPN
+GenericName=VPN Client
+Comment=Qt GUI frontend for Proton VPN CLI
+Exec=proton-vpn-qt-app
+Icon=proton-vpn-qt-app
+Terminal=false
+Type=Application
+Categories=Network;Internet;
+Keywords=VPN;Proton;Network;Security;
+StartupNotify=true

--- a/proton-vpn-sign.svg
+++ b/proton-vpn-sign.svg
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="utf-8"?>
+<svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
+	 viewBox="12 13 25 25" style="enable-background:new 0 0 50 50;" xml:space="preserve">
+<style type="text/css">
+	.st0{fill-rule:evenodd;clip-rule:evenodd;fill:url(#SVGID_1_);}
+	.st1{fill-rule:evenodd;clip-rule:evenodd;fill:url(#SVGID_00000179623718493237744380000001822013374167103378_);}
+	.st2{fill-rule:evenodd;clip-rule:evenodd;fill:url(#SVGID_00000166662081072146141900000011398005821491064979_);}
+	.st3{fill-rule:evenodd;clip-rule:evenodd;fill:url(#SVGID_00000136392201933729594890000013522983325187500444_);}
+</style>
+<g>
+	
+		<linearGradient id="SVGID_1_" gradientUnits="userSpaceOnUse" x1="24.0729" y1="792.7283" x2="24.9134" y2="821.2634" gradientTransform="matrix(1 0 0 1 0 -792)">
+		<stop  offset="0.9887" style="stop-color:#6D4AFF"/>
+		<stop  offset="1" style="stop-color:#000000"/>
+	</linearGradient>
+	<path class="st0" d="M22.2,35.5c0.9,1.7,3.3,1.8,4.4,0.2l9.9-15.1c1.1-1.6,0-3.8-1.9-4l-19.5-2.2c-2.1-0.2-3.6,2-2.5,3.8L22.2,35.5
+		z"/>
+	
+		<linearGradient id="SVGID_00000115482928009205252490000007092240464606197688_" gradientUnits="userSpaceOnUse" x1="24.5884" y1="810.0159" x2="22.6172" y2="828.2148" gradientTransform="matrix(1 0 0 1 0 -792)">
+		<stop  offset="0" style="stop-color:#6D4AFF"/>
+		<stop  offset="1" style="stop-color:#2AE0CA"/>
+	</linearGradient>
+	<path style="fill-rule:evenodd;clip-rule:evenodd;fill:url(#SVGID_00000115482928009205252490000007092240464606197688_);" d="
+		M22.2,35.5c0.9,1.7,3.3,1.8,4.4,0.2l9.9-15.1c1.1-1.6,0-3.8-1.9-4l-19.5-2.2c-2.1-0.2-3.6,2-2.5,3.8L22.2,35.5z"/>
+	
+		<linearGradient id="SVGID_00000102508848256421527460000004188195535591011976_" gradientUnits="userSpaceOnUse" x1="24.5884" y1="810.0159" x2="22.6172" y2="828.2148" gradientTransform="matrix(1 0 0 1 0 -792)">
+		<stop  offset="0" style="stop-color:#6D4AFF"/>
+		<stop  offset="1" style="stop-color:#2AE0CA"/>
+	</linearGradient>
+	<path style="fill-rule:evenodd;clip-rule:evenodd;fill:url(#SVGID_00000102508848256421527460000004188195535591011976_);" d="
+		M22.2,35.5c0.9,1.7,3.3,1.8,4.4,0.2l9.9-15.1c1.1-1.6,0-3.8-1.9-4l-19.5-2.2c-2.1-0.2-3.6,2-2.5,3.8L22.2,35.5z"/>
+	
+		<linearGradient id="SVGID_00000150082972474716683750000015468562722213777566_" gradientUnits="userSpaceOnUse" x1="34.1111" y1="826.7673" x2="18.6361" y2="800.3423" gradientTransform="matrix(1 0 0 1 0 -792)">
+		<stop  offset="6.601250e-02" style="stop-color:#ABFFEF"/>
+		<stop  offset="0.4499" style="stop-color:#CAC9FF"/>
+		<stop  offset="1" style="stop-color:#6D4AFF"/>
+	</linearGradient>
+	<path style="fill-rule:evenodd;clip-rule:evenodd;fill:url(#SVGID_00000150082972474716683750000015468562722213777566_);" d="
+		M23.7,32.8l-0.9,1.3c-0.4,0.5-1.2,0.5-1.5-0.1l0.9,1.6c0.2,0.3,0.4,0.5,0.6,0.7l0,0c1.1,0.9,2.9,0.8,3.8-0.6l9.9-15.1
+		c1.1-1.6,0-3.8-1.9-4l-19.5-2.2c-2.1-0.2-3.6,2-2.5,3.8l0.1,0.1l16.6,1.9c1.1,0.1,1.6,1.3,1,2.2L23.7,32.8z"/>
+</g>
+</svg>

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -34,10 +34,12 @@ set(SOURCES
         cli/natpmpmanager.cpp
         cli/statusmonitor.h
         cli/statusmonitor.cpp
+        cli/flatpakutils.h
         mainwindow.h
         mainwindow.cpp
         widgets/elidalabel.h
         widgets/infobanner.h
+        widgets/flatpakbetabanner.h
         widgets/numberspinner.h
         widgets/pickerbase.h
         widgets/svgbanner.h
@@ -72,6 +74,19 @@ target_link_libraries(proton_vpn_qt
         Qt6::Widgets
         Qt6::Svg
         Qt6::SvgWidgets
+)
+
+install(TARGETS proton_vpn_qt
+        RUNTIME DESTINATION bin
+)
+
+install(FILES ${CMAKE_CURRENT_SOURCE_DIR}/../proton-vpn-qt-app.desktop
+        DESTINATION share/applications
+)
+
+install(FILES ${CMAKE_CURRENT_SOURCE_DIR}/../proton-vpn-sign.svg
+        DESTINATION share/icons/hicolor/scalable/apps
+        RENAME proton-vpn-qt-app.svg
 )
 
 

--- a/src/appconfig.cpp
+++ b/src/appconfig.cpp
@@ -6,10 +6,21 @@
 // ReSharper disable once CppUnusedIncludeDirective
 #include <QJsonDocument> // Ignore unused include warning; we do use QJsonDocument
 #include <QJsonObject>
+#include <QStandardPaths>
 
 // ── Easy-to-change config location ──────────────────────────────────────────
-static const QString kConfigDir = QDir::homePath() + QStringLiteral("/.config/ProtonVPN-Qt");
-static const QString kConfigFile = kConfigDir + QStringLiteral("/app.json");
+// QStandardPaths::GenericConfigLocation resolves to:
+//   - Native install : ~/.config/ProtonVPN-Qt/
+//   - Flatpak sandbox: ~/.var/app/io.github.wheat32.ProtonVPNQt/config/ProtonVPN-Qt/
+// Using this instead of a hardcoded QDir::homePath() path means the Flatpak
+// sandbox XDG remapping is honoured automatically with no extra --filesystem
+// permission required.
+static QString configDir()
+{
+    return QStandardPaths::writableLocation(QStandardPaths::GenericConfigLocation)
+           + QStringLiteral("/ProtonVPN-Qt");
+}
+static QString configFile() { return configDir() + QStringLiteral("/app.json"); }
 // ────────────────────────────────────────────────────────────────────────────
 
 AppConfig& AppConfig::instance()
@@ -25,7 +36,7 @@ AppConfig::AppConfig()
 
 void AppConfig::load()
 {
-    QFile f(kConfigFile);
+    QFile f(configFile());
     if (!f.open(QIODevice::ReadOnly))
         return; // file doesn't exist yet — all values stay at defaults
 
@@ -37,7 +48,7 @@ void AppConfig::load()
     m_recentConnectionsCount = obj.value(QStringLiteral("recent_connections_count")).toInt(5);
     m_startHidden = obj.value(QStringLiteral("start_hidden")).toBool(false);
 
-    DBG_SETTINGS(QStringLiteral("Config loaded from: ") + kConfigFile);
+    DBG_SETTINGS(QStringLiteral("Config loaded from: ") + configFile());
     DBG_SETTINGS(QStringLiteral("  auto_connect             = ") + (m_autoConnect ? QStringLiteral("true") : QStringLiteral("false")));
     DBG_SETTINGS(QStringLiteral("  notifications            = ") + (m_notifications ? QStringLiteral("true") : QStringLiteral("false")));
     DBG_SETTINGS(QStringLiteral("  recent_connections_count = ") + QString::number(m_recentConnectionsCount));
@@ -47,7 +58,7 @@ void AppConfig::load()
 bool AppConfig::save() const
 {
     const QDir dir;
-    if (!dir.mkpath(kConfigDir))
+    if (!dir.mkpath(configDir()))
         return false;
 
     QJsonObject obj;
@@ -56,7 +67,7 @@ bool AppConfig::save() const
     obj[QStringLiteral("recent_connections_count")] = m_recentConnectionsCount;
     obj[QStringLiteral("start_hidden")] = m_startHidden;
 
-    QFile f(kConfigFile);
+    QFile f(configFile());
     if (!f.open(QIODevice::WriteOnly | QIODevice::Text))
         return false;
 
@@ -103,4 +114,3 @@ void AppConfig::setStartHidden(const bool value)
     m_startHidden = value;
     (void)save();
 }
-

--- a/src/cli/flatpakutils.h
+++ b/src/cli/flatpakutils.h
@@ -1,0 +1,34 @@
+#pragma once
+// flatpakutils.h
+// Shared utilities for detecting and adapting to a Flatpak sandbox environment.
+
+#include <QProcessEnvironment>
+#include <QString>
+#include <QStringList>
+#include <utility>
+
+// Returns true when this process is running inside a Flatpak sandbox.
+// The FLATPAK_ID environment variable is always set by the Flatpak runtime.
+inline bool isRunningAsFlatpak()
+{
+    return qEnvironmentVariableIsSet("FLATPAK_ID");
+}
+
+// Returns {program, fullArgs} to run an arbitrary host command via QProcess.
+// When running inside a Flatpak sandbox, the command is forwarded to the host
+// via flatpak-spawn --host. Outside of Flatpak, it is returned unchanged.
+//
+// Example:
+//   auto [prog, args] = buildHostCommand("systemctl", {"--user", "enable", "foo"});
+//   process.start(prog, args);
+inline std::pair<QString, QStringList> buildHostCommand(const QString& program,
+                                                        const QStringList& args = {})
+{
+    if (isRunningAsFlatpak())
+    {
+        QStringList spawnArgs;
+        spawnArgs << QStringLiteral("--host") << program << args;
+        return {QStringLiteral("flatpak-spawn"), spawnArgs};
+    }
+    return {program, args};
+}

--- a/src/cli/protonvpncli.cpp
+++ b/src/cli/protonvpncli.cpp
@@ -6,11 +6,23 @@
 #include "../vpnmanager.h"
 #include "../debug.h"
 #include "statusmonitor.h"
+#include "flatpakutils.h"
 
 #include <QProcess>
 #include <QRegularExpression>
 #include <functional>
 #include <ranges>
+
+// ---------------------------------------------------------------------------
+// Flatpak helper — when running inside a Flatpak sandbox, all CLI calls must
+// be forwarded to the host via flatpak-spawn.
+// ---------------------------------------------------------------------------
+
+// Returns {program, fullArgs} ready for QProcess::start.
+static std::pair<QString, QStringList> buildCliCommand(const QStringList& args)
+{
+    return buildHostCommand(QStringLiteral("protonvpn"), args);
+}
 
 // ---------------------------------------------------------------------------
 // Internal helper — run any protonvpn sub-command asynchronously.
@@ -36,7 +48,8 @@ void VpnManager::runCommand(const QStringList& args,
                 callback(exitCode, out, err);
                 process->deleteLater();
             });
-    process->start(QStringLiteral("protonvpn"), args);
+    auto [program, fullArgs] = buildCliCommand(args);
+    process->start(program, fullArgs);
 }
 
 // ---------------------------------------------------------------------------
@@ -58,7 +71,8 @@ void VpnManager::checkInstalled()
                 DBG_CLI(installed ? QStringLiteral("protonvpn CLI found.") : QStringLiteral("protonvpn CLI NOT found."));
                 emit installedResult(installed);
             });
-    process->start(QStringLiteral("protonvpn"), QStringList{QStringLiteral("--help")});
+    auto [program, fullArgs] = buildCliCommand({QStringLiteral("--help")});
+    process->start(program, fullArgs);
     if (!process->waitForStarted(2000))
     {
         process->deleteLater();
@@ -198,8 +212,8 @@ void VpnManager::login(const QString& username, const QString& password)
                 emit loginFinished(ok, errorMsg);
             });
 
-    process->start(QStringLiteral("protonvpn"),
-                   QStringList{QStringLiteral("signin"), username});
+    auto [program, fullArgs] = buildCliCommand({QStringLiteral("signin"), username});
+    process->start(program, fullArgs);
 }
 
 void VpnManager::cancelLogin()
@@ -312,7 +326,8 @@ void VpnManager::disconnectVpnSync()
     // Used at application exit — run synchronously so the event loop does not
     // need to stay alive.
     QProcess process;
-    process.start(QStringLiteral("protonvpn"), QStringList{QStringLiteral("disconnect")});
+    auto [program, fullArgs] = buildCliCommand({QStringLiteral("disconnect")});
+    process.start(program, fullArgs);
     process.waitForFinished(10000); // up to 10 s
 }
 

--- a/src/cli/statusmonitor.cpp
+++ b/src/cli/statusmonitor.cpp
@@ -3,6 +3,7 @@
 // 15-second loop.  See statusmonitor.h for the full description.
 
 #include "statusmonitor.h"
+#include "flatpakutils.h"
 
 #include <QDebug>
 #include <QTimer>
@@ -22,16 +23,25 @@ static constexpr char kProcessName[] = "protonvpn-qt-status-mon";
 // Shell command run by the subprocess:
 //   1. exec -a renames the bash process to kProcessName (sets argv[0]).
 //   2. The inner bash runs an infinite loop:
-//        a. `protonvpn status` (stdout + stderr merged)
+//        a. `protonvpn status` (stdout + stderr merged) — or via flatpak-spawn
+//           when running inside a Flatpak sandbox.
 //        b. ASCII 0x1E (Record Separator) — unambiguous snapshot delimiter
 //        c. sleep 15
-static const QString kLoopCommand =
-    QStringLiteral("exec -a protonvpn-qt-status-mon /bin/bash -c "
-                   "'while true; "
-                   "do protonvpn status 2>&1; "
-                   "printf \"\\x1e\"; "
-                   "sleep 15; "
-                   "done'");
+static QString buildLoopCommand()
+{
+    // Inside a Flatpak sandbox, `protonvpn` is not available directly — it
+    // must be forwarded to the host via flatpak-spawn.
+    const QString vpnCmd = isRunningAsFlatpak()
+        ? QStringLiteral("flatpak-spawn --host protonvpn status")
+        : QStringLiteral("protonvpn status");
+
+    return QStringLiteral("exec -a protonvpn-qt-status-mon /bin/bash -c "
+                          "'while true; "
+                          "do %1 2>&1; "
+                          "printf \"\\x1e\"; "
+                          "sleep 15; "
+                          "done'").arg(vpnCmd);
+}
 
 // How long to wait before restarting the monitor after an unexpected exit.
 static constexpr int kRestartDelayMs = 5'000;
@@ -125,8 +135,9 @@ void StatusMonitor::launchProcess()
             &QProcess::finished,
             this, &StatusMonitor::onProcessFinished);
 
+    const QString loopCommand = buildLoopCommand();
     m_process->start(QStringLiteral("/bin/bash"),
-                     {QStringLiteral("-c"), kLoopCommand});
+                     {QStringLiteral("-c"), loopCommand});
 
 #ifdef QT_DEBUG
     // waitForStarted so we can log the PID immediately.
@@ -138,7 +149,7 @@ void StatusMonitor::launchProcess()
                kProcessName,
                m_process->processId(),
                m_restartCount,
-               qUtf8Printable(kLoopCommand));
+               qUtf8Printable(loopCommand));
     }
     else
     {

--- a/src/dialogs/aboutdialog.cpp
+++ b/src/dialogs/aboutdialog.cpp
@@ -11,6 +11,7 @@
 #include <QJsonDocument> // Ignore unused include warning; we do use QJsonDocument
 #include <QJsonObject>
 #include <QVersionNumber>
+#include <QProcessEnvironment>
 
 AboutDialog::AboutDialog(const QString& installedCliVersion, QWidget* parent)
     : QDialog(parent)
@@ -71,6 +72,10 @@ AboutDialog::AboutDialog(const QString& installedCliVersion, QWidget* parent)
     versionGrid->addWidget(makeKey(QStringLiteral("Qt version:")),         2, 0);
     versionGrid->addWidget(new QLabel(QStringLiteral(QT_VERSION_STR),      versionWidget), 2, 1);
 
+    const bool isFlatpak = qEnvironmentVariableIsSet("FLATPAK_ID");
+    versionGrid->addWidget(makeKey(QStringLiteral("Package:")),            3, 0);
+    versionGrid->addWidget(new QLabel(isFlatpak ? QStringLiteral("Flatpak") : QStringLiteral("System"), versionWidget), 3, 1);
+
     // Installed CLI version – highlighted only when it differs from tested
     if (!installedCliVersion.isEmpty())
     {
@@ -97,8 +102,8 @@ AboutDialog::AboutDialog(const QString& installedCliVersion, QWidget* parent)
                 QStringLiteral("color: %1; font-weight: bold;").arg(color));
             valLabel->setToolTip(tooltip);
 
-            versionGrid->addWidget(makeKey(QStringLiteral("Installed CLI:")), 3, 0);
-            versionGrid->addWidget(valLabel,                                  3, 1);
+            versionGrid->addWidget(makeKey(QStringLiteral("Installed CLI:")), 4, 0);
+            versionGrid->addWidget(valLabel,                                  4, 1);
         }
     }
 

--- a/src/geoutils.h
+++ b/src/geoutils.h
@@ -27,8 +27,8 @@ namespace GeoUtils
     // Useful for non-square assets such as 4:3 flags.
     QPixmap svgPixmap(const QString& resourcePath, int width, int height);
 
-    // Same as above but colour-tints the rendered pixmap.
-    // Uses CompositionMode_SourceIn to replace colour while preserving alpha.
+    // Same as above but color-tints the rendered pixmap.
+    // Uses CompositionMode_SourceIn to replace color while preserving alpha.
     QPixmap svgPixmap(const QString& resourcePath, int size, const QColor& tint);
     QPixmap svgPixmap(const QString& resourcePath, int width, int height, const QColor& tint);
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -10,6 +10,7 @@
 #include "mainwindow.h"
 #include "appconfig.h"
 #include "debug.h"
+#include "cli/flatpakutils.h"
 #include <QSysInfo>
 #include <QLocale>
 #include <QStandardPaths>
@@ -40,6 +41,7 @@ int main(int argc, char* argv[])
     DBG_APP(QStringLiteral("App version    : ") + appVersion);
     DBG_APP(QStringLiteral("CLI tested for : ") + cliVersionTested);
     DBG_APP(QStringLiteral("Qt version     : ") + QString::fromLatin1(qVersion()));
+    DBG_APP(QStringLiteral("Package type   : ") + (isRunningAsFlatpak() ? QStringLiteral("Flatpak") : QStringLiteral("System")));
     DBG_APP(QStringLiteral("OS             : ") + QSysInfo::prettyProductName());
     DBG_APP(QStringLiteral("Kernel         : ") + QSysInfo::kernelVersion());
     DBG_APP(QStringLiteral("CPU arch       : ") + QSysInfo::currentCpuArchitecture());

--- a/src/pages/loginpage.cpp
+++ b/src/pages/loginpage.cpp
@@ -1,5 +1,6 @@
 #include "loginpage.h"
 #include "../widgets/svgbanner.h"
+#include "../widgets/flatpakbetabanner.h"
 
 #include <QFile>
 #include <QHBoxLayout>
@@ -85,6 +86,7 @@ LoginPage::LoginPage(QWidget* parent)
 
     // Show a banner if this is a pre-release build
     checkPrereleaseBanner();
+    checkFlatpakBetaBanner();
 }
 
 void LoginPage::buildCredsWidget()
@@ -311,6 +313,16 @@ void LoginPage::checkPrereleaseBanner()
         m_prereleaseBanner = nullptr;
     });
     m_outerLayout->addWidget(m_prereleaseBanner);
+}
+
+void LoginPage::checkFlatpakBetaBanner()
+{
+    m_flatpakBetaBanner = FlatpakBetaBanner::createIfFlatpak(this);
+    if (!m_flatpakBetaBanner) return;
+    connect(m_flatpakBetaBanner, &FlatpakBetaBanner::dismissed, this, [this]() {
+        m_flatpakBetaBanner = nullptr;
+    });
+    m_outerLayout->addWidget(m_flatpakBetaBanner);
 }
 
 void LoginPage::onCliVersionReady(const QString& version)

--- a/src/pages/loginpage.h
+++ b/src/pages/loginpage.h
@@ -7,6 +7,7 @@
 #include <QStackedWidget>
 #include <QVBoxLayout>
 #include "../widgets/infobanner.h"
+#include "../widgets/flatpakbetabanner.h"
 #include "../dialogs/errordetailsdialog.h"
 
 class LoginPage : public QWidget
@@ -21,6 +22,7 @@ public:
     void show2FAPrompt() const; // called when VpnManager emits twoFactorRequired()
     void reset() const; // return to username/password view
     void checkPrereleaseBanner();
+    void checkFlatpakBetaBanner();
 
 public slots:
     void onCliVersionReady(const QString& version);
@@ -54,6 +56,7 @@ private:
     QVBoxLayout* m_outerLayout = nullptr;
     InfoBanner* m_versionBanner = nullptr;
     InfoBanner* m_prereleaseBanner = nullptr;
+    FlatpakBetaBanner* m_flatpakBetaBanner = nullptr;
 
     bool m_passwordVisible = false;
     void togglePasswordVisibility() const;

--- a/src/pages/settingspage.cpp
+++ b/src/pages/settingspage.cpp
@@ -3,6 +3,7 @@
 #include "../connectionhistory.h"
 #include "../uihelpers.h"
 #include "../widgets/toggleswitch.h"
+#include "../cli/flatpakutils.h"
 
 #include <QSpinBox>
 #include <QVBoxLayout>
@@ -267,12 +268,14 @@ QString SettingsPage::serviceFilePath()
 
 bool SettingsPage::systemdAvailable()
 {
-    // Check once whether systemctl is on PATH by trying to start it with --version.
+    // Check once whether systemctl is reachable (on the host when in Flatpak).
     static std::optional<bool> cached;
     if (cached.has_value()) return *cached;
 
     QProcess p;
-    p.start(QStringLiteral("systemctl"), {QStringLiteral("--version")});
+    auto [prog, args] = buildHostCommand(QStringLiteral("systemctl"),
+                                         {QStringLiteral("--version")});
+    p.start(prog, args);
     cached = p.waitForStarted(2000) && p.waitForFinished(2000);
     return *cached;
 }
@@ -284,8 +287,11 @@ bool SettingsPage::autoStartEnabled()
 
     // Ask systemd whether the service is enabled. Exit code 0 = enabled.
     QProcess p;
-    p.start(QStringLiteral("systemctl"),
-            {QStringLiteral("--user"), QStringLiteral("is-enabled"), kServiceName});
+    auto [prog, args] = buildHostCommand(QStringLiteral("systemctl"),
+                                         {QStringLiteral("--user"),
+                                          QStringLiteral("is-enabled"),
+                                          kServiceName});
+    p.start(prog, args);
     if (!p.waitForFinished(3000)) return false;
     const QString out = QString::fromUtf8(p.readAllStandardOutput()).trimmed().toLower();
     return out == QStringLiteral("enabled") || out == QStringLiteral("static");
@@ -302,8 +308,12 @@ bool SettingsPage::setAutoStart(const bool enable, QString& errorOut)
 
     if (enable)
     {
-        // Resolve the path to the currently running executable.
-        const QString exe = QCoreApplication::applicationFilePath();
+        // When running as a Flatpak the launcher must be `flatpak run <app-id>`
+        // rather than the sandbox-internal binary path, so the service works
+        // even when the app is not running from within the sandbox at login.
+        const QString exe = isRunningAsFlatpak()
+            ? QStringLiteral("flatpak run io.github.wheat32.ProtonVPNQt")
+            : QCoreApplication::applicationFilePath();
 
         // Create the systemd user service directory if it doesn't exist.
         QDir dir;
@@ -334,8 +344,11 @@ bool SettingsPage::setAutoStart(const bool enable, QString& errorOut)
 
         // Enable the service (creates the symlink so it starts automatically).
         QProcess p;
-        p.start(QStringLiteral("systemctl"),
-                {QStringLiteral("--user"), QStringLiteral("enable"), kServiceName});
+        auto [prog, args] = buildHostCommand(QStringLiteral("systemctl"),
+                                             {QStringLiteral("--user"),
+                                              QStringLiteral("enable"),
+                                              kServiceName});
+        p.start(prog, args);
         p.waitForFinished(5000);
         if (p.exitCode() != 0)
         {
@@ -349,8 +362,11 @@ bool SettingsPage::setAutoStart(const bool enable, QString& errorOut)
     {
         // Disable and remove.
         QProcess p;
-        p.start(QStringLiteral("systemctl"),
-                {QStringLiteral("--user"), QStringLiteral("disable"), kServiceName});
+        auto [prog, args] = buildHostCommand(QStringLiteral("systemctl"),
+                                             {QStringLiteral("--user"),
+                                              QStringLiteral("disable"),
+                                              kServiceName});
+        p.start(prog, args);
         p.waitForFinished(5000);
 
         QFile::remove(serviceFilePath());
@@ -1191,11 +1207,12 @@ SettingsPage::SettingsPage(VpnManager* manager, NatPmpManager* natPmpManager, QW
             // Keep the whole card locked through the Disconnected interim.
             if (state == VpnState::Connected || state == VpnState::Error)
             {
-                // Sequence complete — restore everything.
+                // Sequence complete — re-read settings from disk so the toggles
+                // show the confirmed on-disk state rather than the optimistic one.
+                // refresh() will re-enable everything via setLoading(false) once
+                // the settings are ready.
                 m_sequencePending = false;
-                if (m_vpnCard)    m_vpnCard->setEnabled(true);
-                if (m_refreshBtn) m_refreshBtn->setEnabled(true);
-                updatePlusSectionState();
+                refresh();
             }
             else
             {
@@ -1359,4 +1376,6 @@ void SettingsPage::onSettingsReady(const QMap<QString, QString>& info)
     // individual widgets, so we must restore the correct state afterwards.
     updatePlusSectionState();
 }
+
+
 

--- a/src/pages/vpnpage.cpp
+++ b/src/pages/vpnpage.cpp
@@ -3,6 +3,7 @@
 #include "../connectionhistory.h"
 #include "../uihelpers.h"
 #include "../widgets/svgbanner.h"
+#include "../widgets/flatpakbetabanner.h"
 
 #include <QFile>
 #include <QHBoxLayout>
@@ -918,6 +919,7 @@ VpnPage::VpnPage(VpnManager* manager, QWidget* parent)
     });
     // Show a banner if this is a pre-release build
     checkPrereleaseBanner();
+    checkFlatpakBetaBanner();
 
     // React to plan type (Free vs Plus) — affects picker visibility and connect behaviour.
     connect(m_manager, &VpnManager::accountTypeReady, this, [this](AccountType type)
@@ -1135,6 +1137,24 @@ void VpnPage::checkPrereleaseBanner()
         m_prereleaseBanner = nullptr;
     });
     scrollLayout->insertWidget(0, m_prereleaseBanner);
+}
+
+void VpnPage::checkFlatpakBetaBanner()
+{
+    m_flatpakBetaBanner = FlatpakBetaBanner::createIfFlatpak(this);
+    if (!m_flatpakBetaBanner) return;
+
+    const auto* scrollArea = findChild<QScrollArea*>(QStringLiteral("vpnScrollArea"));
+    if (!scrollArea || !scrollArea->widget()) return;
+    auto* scrollLayout = qobject_cast<QVBoxLayout*>(scrollArea->widget()->layout());
+    if (!scrollLayout) return;
+
+    connect(m_flatpakBetaBanner, &FlatpakBetaBanner::dismissed, this, [this]() {
+        m_flatpakBetaBanner = nullptr;
+    });
+    // Insert below the prerelease banner if present, otherwise at the top
+    const int pos = (m_prereleaseBanner != nullptr) ? 1 : 0;
+    scrollLayout->insertWidget(pos, m_flatpakBetaBanner);
 }
 
 void VpnPage::onCliVersionReady(const QString& version)

--- a/src/pages/vpnpage.h
+++ b/src/pages/vpnpage.h
@@ -8,6 +8,7 @@
 #include "../cli/natpmpmanager.h"
 #include "../widgets/pickerbase.h"
 #include "../widgets/infobanner.h"
+#include "../widgets/flatpakbetabanner.h"
 #include "../dialogs/errordetailsdialog.h"
 
 // ---------------------------------------------------------------------------
@@ -155,6 +156,7 @@ private:
     QHBoxLayout*    m_pickerRow    = nullptr;   // holds both pickers side-by-side
     InfoBanner*     m_versionBanner = nullptr;
     InfoBanner*     m_prereleaseBanner = nullptr;
+    FlatpakBetaBanner* m_flatpakBetaBanner = nullptr;
     QTimer*         m_elapsedTimer;
     QTimer*         m_checkingSpinnerTimer;
     int   m_elapsedSeconds = 0;
@@ -187,6 +189,7 @@ private:
     void showErrorDetails() const;
     void relayoutPickers(int width) const;
     void checkPrereleaseBanner();
+    void checkFlatpakBetaBanner();
     void applyFreeUserMode() const;
     void startNatPmpLoop();
     void stopNatPmpLoop();

--- a/src/version.json
+++ b/src/version.json
@@ -1,5 +1,5 @@
 {
-    "app_version": "1.8.4",
+    "app_version": "1.8.5",
     "prerelease": false,
     "cli_version_tested": "1.0.1"
 }

--- a/src/widgets/flatpakbetabanner.h
+++ b/src/widgets/flatpakbetabanner.h
@@ -1,0 +1,46 @@
+#pragma once
+
+// ============================================================
+// FlatpakBetaBanner
+//
+// Shows a dismissable amber warning banner when the app is running
+// as a Flatpak, indicating that the Flatpak packaging is in beta.
+//
+// TO RETIRE: delete this file and remove:
+//   - #include "widgets/flatpakbetabanner.h"  (in each page)
+//   - m_flatpakBetaBanner member declaration   (in each page .h)
+//   - checkFlatpakBetaBanner() declaration     (in each page .h)
+//   - checkFlatpakBetaBanner() call            (in each page constructor)
+//   - checkFlatpakBetaBanner() implementation  (in each page .cpp)
+// ============================================================
+
+#include "infobanner.h"
+#include "../cli/flatpakutils.h"
+
+class FlatpakBetaBanner : public InfoBanner
+{
+    Q_OBJECT
+public:
+    explicit FlatpakBetaBanner(QWidget* parent = nullptr)
+        : InfoBanner(
+              QStringLiteral(
+                  "The <b>Flatpak</b> packaging of this app is currently in <b>beta</b>. "
+                  "You may encounter issues that do not occur in the native version. "
+                  "Please <a href='https://github.com/wheat32/proton-vpn-qt-app/issues'>"
+                  "report any problems on GitHub</a>."),
+              parent)
+    {}
+
+    // Returns nullptr (and does nothing) when not running as a Flatpak,
+    // so callers can unconditionally assign the result to a pointer member.
+    static FlatpakBetaBanner* createIfFlatpak(QWidget* parent)
+    {
+        if (!isRunningAsFlatpak())
+        {
+            return nullptr;
+        }
+        return new FlatpakBetaBanner(parent);
+    }
+};
+
+

--- a/src/widgets/infobanner.h
+++ b/src/widgets/infobanner.h
@@ -23,17 +23,17 @@ public:
     explicit InfoBanner(const QString& htmlMessage, QWidget* parent = nullptr)
         : QFrame(parent)
     {
-        static const std::string kColour       = "#7a5c00";
-        static const std::string kBgColour     = "#fff3cd";
-        static const std::string kBorderColour = "#e6ac00";
+        static const std::string kColor       = "#7a5c00";
+        static const std::string kBgColor     = "#fff3cd";
+        static const std::string kBorderColor = "#e6ac00";
 
         setStyleSheet(
             QStringLiteral(
                 "QFrame { background-color: %1; border: 1px solid %2; border-radius: 6px; } "
                 "QLabel { color: %3; background: transparent; }")
-            .arg(QLatin1String(kBgColour),
-                 QLatin1String(kBorderColour),
-                 QLatin1String(kColour)));
+            .arg(QLatin1String(kBgColor),
+                 QLatin1String(kBorderColor),
+                 QLatin1String(kColor)));
 
         auto* layout = new QHBoxLayout(this);
         layout->setContentsMargins(12, 8, 8, 8);
@@ -46,6 +46,7 @@ public:
         auto* msgLabel = new QLabel(htmlMessage, this);
         msgLabel->setWordWrap(true);
         msgLabel->setTextFormat(Qt::RichText);
+        msgLabel->setOpenExternalLinks(true);
         msgLabel->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Preferred);
         layout->addWidget(msgLabel, 1);
 
@@ -56,7 +57,7 @@ public:
         dismissBtn->setStyleSheet(
             QStringLiteral("QPushButton { color: %1; font-weight: bold; border: none; "
                            "background: transparent; } QPushButton:hover { opacity: 0.7; }")
-                .arg(QLatin1String(kColour)));
+                .arg(QLatin1String(kColor)));
         connect(dismissBtn, &QPushButton::clicked, this, &InfoBanner::dismiss);
         layout->addWidget(dismissBtn, 0, Qt::AlignTop);
     }

--- a/src/widgets/numberspinner.h
+++ b/src/widgets/numberspinner.h
@@ -98,7 +98,7 @@ signals:
 
 private:
     // Load an SVG from a Qt resource, patch currentColor to the app text
-    // colour in memory (never touching the file on disk), and return a QIcon.
+    // color in memory (never touching the file on disk), and return a QIcon.
     static QIcon svgIcon(const QString& resource)
     {
         QFile file(resource);


### PR DESCRIPTION
- Add Flatpak build/release support and adapt the app to run correctly inside a Flatpak sandbox.
- CI: add workflow_dispatch and new Flatpak build jobs to ci.yml and release.yml, upload artifacts, and create a separate release job that includes both native tarball and Flatpak bundle.
- Packaging: add Flatpak manifest (io.github.wheat32.ProtonVPNQt.yml), build helper script (build-flatpak.sh), and desktop file and SVG icon. -Build: install targets added to CMakeLists.txt to package the desktop file and icon.
- Runtime changes: introduce cli/flatpakutils.h for sandbox detection and command forwarding via flatpak-spawn; update protonvpn CLI calls, status monitor loop, and systemd auto-start logic to use host commands when needed.
- Config handling now uses QStandardPaths so XDG remapping inside Flatpak is respected.
- UI: add a dismissable Flatpak beta InfoBanner and show package type in About; minor tweaks to InfoBanner (link behavior and name spelling) and other UI integrations.
- Bump app version to 1.8.5.