### PR TITLE
Expose VPN status over D-Bus and enhance auto-connect server selection

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,6 +136,57 @@ tar -xzf proton-vpn-qt-app-linux-x86_64.tar.gz
 
 ---
 
+## D-Bus Interface
+
+While running, the app registers a D-Bus service on the **session bus** that any other application or script can query.
+
+| | Value |
+|---|---|
+| **Service** | `com.protonvpn.app` |
+| **Object path** | `/com/protonvpn/app` |
+| **Interface** | `com.protonvpn.app.Status` |
+
+### Properties (read-only)
+
+| Property | Type | Description |
+|---|---|---|
+| `Status` | `string` | Current VPN state: `connected`, `connecting`, `disconnected`, `disconnecting`, `error`, or `unknown` |
+| `ConnectedServer` | `string` | Active server name (e.g. `US-NJ#189`) while connected; empty otherwise |
+
+### Signals
+
+| Signal | Arguments | Description |
+|---|---|---|
+| `StatusChanged` | `status: string` | Emitted on every VPN state transition |
+
+### Example usage
+
+```bash
+# Read current status
+gdbus call --session \
+  --dest com.protonvpn.app \
+  --object-path /com/protonvpn/app \
+  --method org.freedesktop.DBus.Properties.Get \
+  com.protonvpn.app.Status Status
+
+# Read all properties at once
+gdbus call --session \
+  --dest com.protonvpn.app \
+  --object-path /com/protonvpn/app \
+  --method org.freedesktop.DBus.Properties.GetAll \
+  com.protonvpn.app.Status
+
+# Monitor live state change signals
+gdbus monitor --session --dest com.protonvpn.app
+
+# Introspect the full interface
+gdbus introspect --session \
+  --dest com.protonvpn.app \
+  --object-path /com/protonvpn/app
+```
+
+---
+
 ## Author & Credits
 
 - **Nicholas Page** ([wheat32](https://github.com/wheat32)) — author

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -16,6 +16,7 @@ find_package(Qt6 COMPONENTS
         Widgets
         Svg
         SvgWidgets
+        DBus
         REQUIRED)
 
 find_package(Qt6 COMPONENTS LinguistTools QUIET)
@@ -35,6 +36,8 @@ set(SOURCES
         uihelpers.h
         vpnmanager.h
         vpnmanager.cpp
+        dbus/vpnstatusadaptor.h
+        dbus/vpnstatusadaptor.cpp
         cli/protonvpncli.cpp
         cli/natpmpmanager.h
         cli/natpmpmanager.cpp
@@ -98,6 +101,7 @@ target_link_libraries(proton_vpn_qt
         Qt6::Widgets
         Qt6::Svg
         Qt6::SvgWidgets
+        Qt6::DBus
 )
 
 install(TARGETS proton_vpn_qt

--- a/src/appconfig.cpp
+++ b/src/appconfig.cpp
@@ -44,6 +44,7 @@ void AppConfig::load()
     f.close();
 
     m_autoConnect = obj.value(QStringLiteral("auto_connect")).toBool(false);
+    m_autoConnectServer = obj.value(QStringLiteral("auto_connect_server")).toString();
     m_notifications = obj.value(QStringLiteral("notifications")).toBool(true);
     m_recentConnectionsCount = obj.value(QStringLiteral("recent_connections_count")).toInt(5);
     m_startHidden = obj.value(QStringLiteral("start_hidden")).toBool(false);
@@ -83,6 +84,8 @@ bool AppConfig::save() const
 
     QJsonObject obj;
     obj[QStringLiteral("auto_connect")] = m_autoConnect;
+    if (!m_autoConnectServer.isEmpty())
+        obj[QStringLiteral("auto_connect_server")] = m_autoConnectServer;
     obj[QStringLiteral("notifications")] = m_notifications;
     obj[QStringLiteral("recent_connections_count")] = m_recentConnectionsCount;
     obj[QStringLiteral("start_hidden")] = m_startHidden;
@@ -119,11 +122,21 @@ bool AppConfig::save() const
 
 bool AppConfig::autoConnect() const { return m_autoConnect; }
 
+QString AppConfig::autoConnectServer() const { return m_autoConnectServer; }
+
 void AppConfig::setAutoConnect(bool value)
 {
     if (m_autoConnect == value) return;
     DBG_SETTINGS(QStringLiteral("Setting changed: auto_connect = ") + (value ? QStringLiteral("true") : QStringLiteral("false")));
     m_autoConnect = value;
+    (void)save();
+}
+
+void AppConfig::setAutoConnectServer(const QString& value)
+{
+    if (m_autoConnectServer == value) return;
+    DBG_SETTINGS(QStringLiteral("Setting changed: auto_connect_server = ") + value);
+    m_autoConnectServer = value;
     (void)save();
 }
 
@@ -215,6 +228,7 @@ void AppConfig::resetToDefaults()
 
     // Reset every member to its compile-time default.
     m_autoConnect            = false;
+    m_autoConnectServer      = QString();
     m_notifications          = true;
     m_recentConnectionsCount = 5;
     m_startHidden            = false;

--- a/src/appconfig.h
+++ b/src/appconfig.h
@@ -15,6 +15,9 @@ public:
     static AppConfig &instance();
 
     bool autoConnect() const;
+    // Empty string means "Fastest Server"; "CC" means fastest in country;
+    // "CC|city" means a specific city.  Stored as-is.
+    QString autoConnectServer() const;
     bool notifications() const;
     int  recentConnectionsCount() const;
     bool startHidden() const;
@@ -25,6 +28,7 @@ public:
     QString lastSeenVersion() const;
 
     void setAutoConnect(bool value);
+    void setAutoConnectServer(const QString& value);
     void setNotifications(bool value);
     void setRecentConnectionsCount(int value);
     void setStartHidden(bool value);
@@ -45,6 +49,7 @@ private:
     bool save() const;
 
     bool m_autoConnect    = false;
+    QString m_autoConnectServer;
     bool m_notifications  = true;
     int  m_recentConnectionsCount = 5;
     bool m_startHidden = false;

--- a/src/dbus/vpnstatusadaptor.cpp
+++ b/src/dbus/vpnstatusadaptor.cpp
@@ -1,0 +1,44 @@
+#include "vpnstatusadaptor.h"
+
+VpnStatusAdaptor::VpnStatusAdaptor(VpnManager* parent)
+    : QDBusAbstractAdaptor(parent)
+    , m_manager(parent)
+{
+    setAutoRelaySignals(false);
+    connect(m_manager, &VpnManager::connectionStateChanged,
+            this,      &VpnStatusAdaptor::onConnectionStateChanged);
+}
+
+QString VpnStatusAdaptor::status() const
+{
+    return stateToString(m_manager->currentState());
+}
+
+QString VpnStatusAdaptor::connectedServer() const
+{
+    return m_manager->connectedServer();
+}
+
+void VpnStatusAdaptor::onConnectionStateChanged(const VpnState state, const QString& /*info*/)
+{
+    emit StatusChanged(stateToString(state));
+}
+
+QString VpnStatusAdaptor::stateToString(const VpnState state)
+{
+    switch (state)
+    {
+        case VpnState::Disconnected:
+            return QStringLiteral("disconnected");
+        case VpnState::Connecting:
+            return QStringLiteral("connecting");
+        case VpnState::Connected:
+            return QStringLiteral("connected");
+        case VpnState::Disconnecting:
+            return QStringLiteral("disconnecting");
+        case VpnState::Error:
+            return QStringLiteral("error");
+        default:
+            return QStringLiteral("unknown");
+    }
+}

--- a/src/dbus/vpnstatusadaptor.h
+++ b/src/dbus/vpnstatusadaptor.h
@@ -1,0 +1,47 @@
+#pragma once
+
+#include <QDBusAbstractAdaptor>
+#include <QString>
+#include "../vpnmanager.h"
+
+/**
+ * D-Bus adaptor that exposes the VPN connection status on the session bus.
+ *
+ * Service name : com.protonvpn.app
+ * Object path  : /com/protonvpn/app
+ * Interface    : com.protonvpn.app.Status
+ *
+ * Properties (read-only):
+ *   Status          – "unknown" | "disconnected" | "connecting" |
+ *                     "connected" | "disconnecting" | "error"
+ *   ConnectedServer – server string while connected (e.g. "US-NJ#189"),
+ *                     empty when not connected
+ *
+ * Signals:
+ *   StatusChanged(status: string)  – fired on every VPN state transition
+ */
+class VpnStatusAdaptor : public QDBusAbstractAdaptor
+{
+    Q_OBJECT
+    Q_CLASSINFO("D-Bus Interface", "com.protonvpn.app.Status")
+
+    Q_PROPERTY(QString Status          READ status)
+    Q_PROPERTY(QString ConnectedServer READ connectedServer)
+
+public:
+    explicit VpnStatusAdaptor(VpnManager* parent);
+
+    QString status()          const;
+    QString connectedServer() const;
+
+signals:
+    void StatusChanged(const QString& status);
+
+private slots:
+    void onConnectionStateChanged(VpnState state, const QString& info);
+
+private:
+    VpnManager* m_manager; // non-owning; lifetime is managed by MainWindow
+    static QString stateToString(VpnState state);
+};
+

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -11,10 +11,13 @@
 #include "thememanager.h"
 #include "debug.h"
 #include "cli/flatpakutils.h"
+#include "dbus/vpnstatusadaptor.h"
 #include <QSysInfo>
 #include <QLocale>
 #include <QStandardPaths>
 #include <QTranslator>
+#include <QDBusConnection>
+#include <QDBusError>
 
 int main(int argc, char* argv[])
 {
@@ -93,6 +96,31 @@ int main(int argc, char* argv[])
     ThemeManager::apply(AppConfig::instance().theme());
 
     MainWindow w;
+
+    // Expose VPN status on the D-Bus session bus so any other app can query it.
+    // The adaptor must be parented to the adapted object (VpnManager), and the
+    // service/object registration is done here in main so the lifetime is clear.
+    VpnStatusAdaptor* dbusAdaptor = new VpnStatusAdaptor(w.manager());
+    Q_UNUSED(dbusAdaptor)
+    QDBusConnection sessionBus = QDBusConnection::sessionBus();
+    if (sessionBus.isConnected())
+    {
+        sessionBus.registerObject(QStringLiteral("/com/protonvpn/app"), w.manager());
+        if (sessionBus.registerService(QStringLiteral("com.protonvpn.app")) == false)
+        {
+            DBG_APP(QStringLiteral("D-Bus: failed to register service com.protonvpn.app: ") +
+                    sessionBus.lastError().message());
+        }
+        else
+        {
+            DBG_APP(QStringLiteral("D-Bus: service com.protonvpn.app registered on session bus"));
+        }
+    }
+    else
+    {
+        DBG_APP(QStringLiteral("D-Bus: cannot connect to session bus — VPN status will not be exposed"));
+    }
+
     if (AppConfig::instance().startHidden())
         w.hide();
     else

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -297,7 +297,18 @@ MainWindow::MainWindow(QWidget* parent)
                 if (m_startupAutoConnectPending && state == VpnState::Disconnected)
                 {
                     m_startupAutoConnectPending = false;
-                    m_manager->connectVpn();
+                    const QString serverKey = AppConfig::instance().autoConnectServer();
+                    if (serverKey.isEmpty())
+                    {
+                        m_manager->connectVpn();
+                    }
+                    else
+                    {
+                        const int sep = serverKey.indexOf(QLatin1Char('|'));
+                        const QString country = (sep >= 0) ? serverKey.left(sep) : serverKey;
+                        const QString city    = (sep >= 0) ? serverKey.mid(sep + 1) : QString();
+                        m_manager->connectVpn(country, city);
+                    }
                 }
             });
 

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -66,6 +66,7 @@ MainWindow::MainWindow(QWidget* parent)
 
     m_manager = new VpnManager(this);
 
+
     // Root layout: sidebar + content
     auto* rootLayout = new QHBoxLayout(this);
     rootLayout->setContentsMargins(0, 0, 0, 0);

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -25,6 +25,8 @@ class MainWindow : public QWidget
 public:
     explicit MainWindow(QWidget* parent = nullptr);
 
+    VpnManager* manager() const { return m_manager; }
+
 private:
     enum class Page
     {

--- a/src/pages/settingspage.cpp
+++ b/src/pages/settingspage.cpp
@@ -437,6 +437,71 @@ void SettingsPage::updateAutoConnectRowVisibility() const
         m_autoConnectToggle->setOn(false, false);
         AppConfig::instance().setAutoConnect(false);
     }
+    updateAutoConnectServerRow();
+}
+
+void SettingsPage::populateAutoConnectServerCombo() const
+{
+    if (m_autoConnectServerCombo == nullptr) return;
+
+    const QString saved = AppConfig::instance().autoConnectServer();
+
+    // Block signals while rebuilding to avoid spurious saves.
+    QSignalBlocker blocker(m_autoConnectServerCombo);
+    m_autoConnectServerCombo->clear();
+    m_autoConnectServerCombo->addItem(tr("Fastest Server"), QString());
+
+    const QList<FavoriteEntry> favs = FavoritesManager::instance().entries();
+    for (const FavoriteEntry& e : favs)
+    {
+        const QString key = e.city.isEmpty()
+            ? e.countryCode
+            : e.countryCode + QStringLiteral("|") + e.city;
+        const QString display = e.city.isEmpty()
+            ? tr("%1 — Fastest").arg(e.countryName)
+            : tr("%1 — %2").arg(e.countryName, e.city);
+        m_autoConnectServerCombo->addItem(display, key);
+    }
+
+    // Restore saved selection (or stay on index 0 if not found).
+    int idx = 0;
+    for (int i = 1; i < m_autoConnectServerCombo->count(); ++i)
+    {
+        if (m_autoConnectServerCombo->itemData(i).toString() == saved)
+        {
+            idx = i;
+            break;
+        }
+    }
+    m_autoConnectServerCombo->setCurrentIndex(idx);
+}
+
+void SettingsPage::updateAutoConnectServerRow() const
+{
+    if (m_autoConnectServerRow == nullptr) return;
+
+    const bool autoConnectOn = m_autoConnectToggle != nullptr && m_autoConnectToggle->isOn();
+    const bool autoStartOn   = m_autoStartToggle   != nullptr && m_autoStartToggle->isOn();
+    const bool show          = autoStartOn && autoConnectOn;
+    m_autoConnectServerRow->setVisible(show);
+
+    if (m_autoConnectServerCombo == nullptr) return;
+
+    const bool hasFavorites = FavoritesManager::instance().hasAnyEntries();
+    // Disable the whole row (grays out the label too) but keep the tooltip
+    // on the row itself so it shows even when the row is disabled.
+    m_autoConnectServerRow->setEnabled(hasFavorites);
+    if (!hasFavorites)
+    {
+        const QString tip = tr("Add favorite servers to choose a specific server for auto-connect.");
+        m_autoConnectServerRow->setToolTip(tip);
+        m_autoConnectServerCombo->setToolTip(tip);
+    }
+    else
+    {
+        m_autoConnectServerRow->setToolTip(QString());
+        m_autoConnectServerCombo->setToolTip(QString());
+    }
 }
 
 SettingsPage::SettingsPage(VpnManager* manager, NatPmpManager* natPmpManager, QWidget* parent)
@@ -604,6 +669,37 @@ SettingsPage::SettingsPage(VpnManager* manager, NatPmpManager* natPmpManager, QW
             acRl->addWidget(m_autoConnectToggle);
             startupLayout->addWidget(m_autoConnectRow); // direct add – no divider above it
             updateAutoConnectRowVisibility();
+
+            // Sub-sub-row: indented server dropdown (no divider – belongs to auto-connect)
+            m_autoConnectServerRow = new QWidget(startupCard);
+            auto* srvRl = new QHBoxLayout(m_autoConnectServerRow);
+            srvRl->setContentsMargins(48, 4, 16, 12);
+            srvRl->setSpacing(16);
+            srvRl->addWidget(makeTextCol(m_autoConnectServerRow,
+                                         tr("Server"),
+                                         tr("Choose which server to connect to on startup.")), 1);
+            m_autoConnectServerCombo = new QComboBox(m_autoConnectServerRow);
+            m_autoConnectServerCombo->setMinimumWidth(180);
+            populateAutoConnectServerCombo();
+            connect(m_autoConnectServerCombo, &QComboBox::currentIndexChanged, this, [this](int idx)
+            {
+                const QString val = m_autoConnectServerCombo->itemData(idx).toString();
+                AppConfig::instance().setAutoConnectServer(val);
+            });
+            // Keep the combo up-to-date when favorites change.
+            connect(&FavoritesManager::instance(), &FavoritesManager::changed, this, [this]()
+            {
+                populateAutoConnectServerCombo();
+                updateAutoConnectServerRow();
+            });
+            // Show/hide when auto-connect toggle changes.
+            connect(m_autoConnectToggle, &ToggleWithStatus::toggled, this, [this](bool)
+            {
+                updateAutoConnectServerRow();
+            });
+            srvRl->addWidget(m_autoConnectServerCombo);
+            startupLayout->addWidget(m_autoConnectServerRow); // direct add – no divider above it
+            updateAutoConnectServerRow();
         }
 
         // Start Hidden

--- a/src/pages/settingspage.cpp
+++ b/src/pages/settingspage.cpp
@@ -347,9 +347,19 @@ bool SettingsPage::setAutoStart(const bool enable, QString& errorOut)
         // When running as a Flatpak the launcher must be `flatpak run <app-id>`
         // rather than the sandbox-internal binary path, so the service works
         // even when the app is not running from within the sandbox at login.
-        const QString exe = isRunningAsFlatpak()
-            ? QStringLiteral("flatpak run io.github.wheat32.ProtonVPNQt")
-            : QCoreApplication::applicationFilePath();
+        // systemd requires an absolute path in ExecStart, so we resolve the
+        // full path to the flatpak binary (typically /usr/bin/flatpak).
+        QString exe;
+        if (isRunningAsFlatpak())
+        {
+            const QString flatpakBin = QStandardPaths::findExecutable(QStringLiteral("flatpak"));
+            exe = (flatpakBin.isEmpty() ? QStringLiteral("/usr/bin/flatpak") : flatpakBin)
+                  + QStringLiteral(" run io.github.wheat32.ProtonVPNQt");
+        }
+        else
+        {
+            exe = QCoreApplication::applicationFilePath();
+        }
 
         // Create the systemd user service directory if it doesn't exist.
         if (QDir().mkpath(kSystemdUserServiceDir) == false)
@@ -488,12 +498,21 @@ SettingsPage::SettingsPage(VpnManager* manager, NatPmpManager* natPmpManager, QW
         appContentLayout->setSpacing(8);
         scroll->setWidget(appContent);
 
-        // Helper: add a section header label (uppercase, muted)
+        // Helper: add a section header label with an optional top separator
+        bool appFirstSection = true;
         auto addHeader = [&](const QString& title)
         {
+            if (!appFirstSection) {
+                auto* sep = new QFrame(appContent);
+                sep->setFrameShape(QFrame::HLine);
+                sep->setObjectName(QStringLiteral("appSectionDivider"));
+                appContentLayout->addWidget(sep);
+            }
+            appFirstSection = false;
+
             auto* w = new QWidget(appContent);
             auto* hl = new QHBoxLayout(w);
-            hl->setContentsMargins(4, 8, 4, 2);
+            hl->setContentsMargins(4, 16, 4, 4);
             auto* lbl = new QLabel(title.toUpper(), w);
             lbl->setObjectName(QStringLiteral("appSectionHeader"));
             hl->addWidget(lbl);
@@ -645,11 +664,20 @@ SettingsPage::SettingsPage(VpnManager* manager, NatPmpManager* natPmpManager, QW
         appContentLayout->addWidget(m_appPlusSection);
 
         // Section header helper that targets m_appPlusSection
+        bool plusFirstSection = true;
         auto addPlusHeader = [&](const QString& title)
         {
+            if (!plusFirstSection) {
+                auto* sep = new QFrame(m_appPlusSection);
+                sep->setFrameShape(QFrame::HLine);
+                sep->setObjectName(QStringLiteral("appSectionDivider"));
+                appPlusSectionLayout->addWidget(sep);
+            }
+            plusFirstSection = false;
+
             auto* w = new QWidget(m_appPlusSection);
             auto* hl = new QHBoxLayout(w);
-            hl->setContentsMargins(4, 4, 4, 2);
+            hl->setContentsMargins(4, 16, 4, 4);
             auto* lbl = new QLabel(title.toUpper(), w);
             lbl->setObjectName(QStringLiteral("appSectionHeader"));
             hl->addWidget(lbl);

--- a/src/pages/settingspage.h
+++ b/src/pages/settingspage.h
@@ -79,6 +79,10 @@ private:
     ToggleWithStatus* m_autoConnectToggle = nullptr;
     QWidget* m_autoConnectRow = nullptr;
 
+    // Auto-connect server dropdown (shown only when auto-connect is on)
+    QWidget*   m_autoConnectServerRow   = nullptr;
+    QComboBox* m_autoConnectServerCombo = nullptr;
+
     // Desktop notifications
     ToggleWithStatus* m_notificationsToggle = nullptr;
 
@@ -151,6 +155,8 @@ private:
     static bool autoStartEnabled();
     static bool setAutoStart(bool enable, QString& errorOut);
     void updateAutoConnectRowVisibility() const;
+    void updateAutoConnectServerRow() const;
+    void populateAutoConnectServerCombo() const;
 
     void onSettingsReady(const QMap<QString, QString>& settings);
     void setLoading(bool loading);

--- a/src/style.qss
+++ b/src/style.qss
@@ -401,10 +401,17 @@ QFrame#plusDividerLine {
 /* ── App-tab section headers ── */
 QLabel#appSectionHeader {
     color: #c0b8e8;
-    font-size: 12px;
+    font-size: 13px;
     font-weight: 700;
-    letter-spacing: 1px;
+    letter-spacing: 1.5px;
     background-color: transparent;
+}
+QFrame#appSectionDivider {
+    color: #3a3a55;
+    background-color: #3a3a55;
+    max-height: 1px;
+    border: none;
+    margin: 8px 0px 0px 0px;
 }
 
 /* ── About nav row (clickable settings-style row) ── */

--- a/src/style.qss
+++ b/src/style.qss
@@ -473,3 +473,15 @@ QFrame#drawerNotch:hover {
     background-color: #2d2d4a;
 }
 
+QComboBox:disabled {
+    color: #555570;
+    background-color: #1e1e32;
+    border-color: #2a2a40;
+}
+QComboBox::drop-down:disabled {
+    border-color: #2a2a40;
+}
+QComboBox::down-arrow:disabled {
+    opacity: 0.3;
+}
+

--- a/src/style_light.qss
+++ b/src/style_light.qss
@@ -470,3 +470,16 @@ QFrame#drawerNotch {
 QFrame#drawerNotch:hover {
     background-color: #d0d0e8;
 }
+
+QComboBox:disabled {
+    color: #aaaabb;
+    background-color: #e0e0ea;
+    border-color: #c0c0d0;
+}
+QComboBox::drop-down:disabled {
+    border-color: #c0c0d0;
+}
+QComboBox::down-arrow:disabled {
+    opacity: 0.3;
+}
+

--- a/src/style_light.qss
+++ b/src/style_light.qss
@@ -401,10 +401,17 @@ QFrame#plusDividerLine {
 /* ── App-tab section headers ── */
 QLabel#appSectionHeader {
     color: #4a3a9a;
-    font-size: 12px;
+    font-size: 13px;
     font-weight: 700;
-    letter-spacing: 1px;
+    letter-spacing: 1.5px;
     background-color: transparent;
+}
+QFrame#appSectionDivider {
+    color: #c8c8dc;
+    background-color: #c8c8dc;
+    max-height: 1px;
+    border: none;
+    margin: 8px 0px 0px 0px;
 }
 
 /* ── About nav row (clickable settings-style row) ── */

--- a/src/version.json
+++ b/src/version.json
@@ -1,5 +1,5 @@
 {
-    "app_version": "1.9.0-rc.1",
+    "app_version": "1.9.0-rc.2",
     "prerelease": true,
     "cli_version_tested": "1.0.1"
 }

--- a/src/vpnmanager.h
+++ b/src/vpnmanager.h
@@ -61,6 +61,8 @@ public:
     // Last country / city passed to connectVpn() — empty if connected via CLI.
     QString     lastConnectCountry() const { return m_lastConnectCountry; }
     QString     lastConnectCity()    const { return m_lastConnectCity; }
+    // Last server string seen while Connected (e.g. "US-NJ#189") — empty otherwise.
+    QString     connectedServer()    const { return m_connectedServer; }
     // Reads the port-forwarding setting directly from the settings JSON file.
     bool        portForwardingEnabled() const;
 


### PR DESCRIPTION
- Add a QDBus adaptor (VpnStatusAdaptor) that exposes com.protonvpn.app.Status on the session bus (read-only properties Status and ConnectedServer, plus StatusChanged signal) and register it from main.

- Update CMake to find/link Qt DBus and add adaptor sources.

- Provide MainWindow::manager() and VpnManager::connectedServer() accessors used by the adaptor.

- Document the new D-Bus interface in README.

- Fix settings auto-start ExecStart for Flatpak by resolving the absolute flatpak binary path.

- Make several UI/stylesheet adjustments: add section dividers, increase section header spacing/letter-spacing, and tweak margins.

- Allow selecting a specific server to use for startup auto-connect.

- Persist the choice in AppConfig (string format: "" = Fastest Server, "CC" = country, "CC|city" = specific city); add getter/setter, include it in load/save (save omits the key if empty), and reset it to default.

- MainWindow now uses the stored value on startup to call connectVpn(country, city) when appropriate, falling back to the existing connectVpn() for the fastest-server mode.

- SettingsPage UI: add an indented combo to choose the server, populate it from FavoritesManager entries, keep it synchronized with favorites and auto-connect toggles, and disable/show helpful tooltip when no favorites exist.

- Also add QComboBox:disabled styling rules for dark and light themes.