### PR TITLE
Move AppStream metainfo install to CMake

### DIFF
--- a/io.github.wheat32.ProtonVPNQt.yml
+++ b/io.github.wheat32.ProtonVPNQt.yml
@@ -42,9 +42,7 @@ modules:
       # Rename the .desktop file itself to the app-id (required by Flatpak)
       - mv /app/share/applications/proton-vpn-qt-app.desktop
           /app/share/applications/io.github.wheat32.ProtonVPNQt.desktop
-      # Install AppStream metainfo (required by Flathub)
-      - install -Dm644 ../io.github.wheat32.ProtonVPNQt.metainfo.xml
-          /app/share/metainfo/io.github.wheat32.ProtonVPNQt.metainfo.xml
+
     sources:
       - type: dir
         path: .

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -117,6 +117,10 @@ install(FILES ${CMAKE_CURRENT_SOURCE_DIR}/../proton-vpn-sign.svg
         RENAME proton-vpn-qt-app.svg
 )
 
+install(FILES ${CMAKE_CURRENT_SOURCE_DIR}/../io.github.wheat32.ProtonVPNQt.metainfo.xml
+        DESTINATION share/metainfo
+)
+
 # ── Tests ────────────────────────────────────────────────────────────────────
 enable_testing()
 add_subdirectory(tests)


### PR DESCRIPTION
Remove metainfo install commands from the Flatpak manifest and add a CMake install rule for io.github.wheat32.ProtonVPNQt.metainfo.xml (DESTINATION share/metainfo). This centralizes installation of the AppStream metainfo into the build system and avoids duplicating installation steps in the Flatpak YAML.