### PR TITLE
Add banner scroll area; AppImage packaging fixes

### DIFF
--- a/build-appimage.sh
+++ b/build-appimage.sh
@@ -142,6 +142,14 @@ python3 -m venv "${VENV}"
     aiohttp bcrypt python-gnupg pyOpenSSL requests "importlib-metadata" \
     keyring secretstorage cryptography distro fido2 Jinja2 PyNaCl sentry-sdk
 
+# Remove compiled C extensions (.so files) from the venv site-packages.
+# They were compiled against the CI machine's Python ABI and will fail to
+# load on distributions with a differently built Python (e.g. Arch vs Ubuntu).
+# Python falls back to the system package for native modules; the key ones
+# needed are: python3-cffi, python3-cryptography, python3-nacl, python3-bcrypt.
+find "${VENV}/lib" -path "*/site-packages/*" -name "*.so" -delete
+find "${VENV}/lib" -path "*/site-packages/*" -name "*.so.*" -delete
+
 PY_VER=$("${VENV}/bin/python3" -c \
     "import sys; print(f'python{sys.version_info.major}.{sys.version_info.minor}')")
 
@@ -244,10 +252,12 @@ export PATH="${TOOLS_DIR}:${PATH}"
 # NO_STRIP=1 prevents linuxdeploy's bundled strip from choking on modern
 # ELF libraries that use .relr.dyn (requires binutils 2.38+).
 NO_STRIP=1 APPIMAGE_EXTRACT_AND_RUN=1 "${LINUXDEPLOY}" \
-    --appdir       "${APPDIR}" \
-    --executable   "${APPDIR}/usr/bin/proton_vpn_qt" \
-    --desktop-file "${DESKTOP_DST}" \
-    --icon-file    "${ICON_DIR}/${APP_ID}.svg"
+    --appdir          "${APPDIR}" \
+    --executable      "${APPDIR}/usr/bin/proton_vpn_qt" \
+    --desktop-file    "${DESKTOP_DST}" \
+    --icon-file       "${ICON_DIR}/${APP_ID}.svg" \
+    --exclude-library "libssl*" \
+    --exclude-library "libcrypto*"
 
 # Step 2 -- deploy Qt plugins (platform, imageformats, etc.).
 # The linuxdeploy-plugin-qt AppImage wrapper resets $QMAKE before calling the

--- a/src/pages/loginPage.cpp
+++ b/src/pages/loginPage.cpp
@@ -3,6 +3,7 @@
 #include "../widgets/svgBanner.h"
 
 #include <QFile>
+#include <QFrame>
 #include <QHBoxLayout>
 // ReSharper disable once CppUnusedIncludeDirective
 #include <QJsonDocument> // Ignore unused include warning; we do use QJsonDocument
@@ -16,6 +17,7 @@
 namespace
 {
 constexpr int LOGIN_CARD_WIDTH          = 360;
+constexpr int BANNER_AREA_MAX_HEIGHT    = 150;
 constexpr int LOGIN_LAYOUT_SPACING      = 16;
 constexpr int LOGIN_H_MARGIN            = 32;
 constexpr int LOGIN_TOP_MARGIN          = 32;
@@ -106,6 +108,23 @@ LoginPage::LoginPage(QWidget* parent)
     cardLayout->addWidget(m_errorContainer);
 
     m_outerLayout->addWidget(card, 0, Qt::AlignCenter);
+
+    // Banner scroll area — holds warning banners below the card.
+    // Capped at BANNER_AREA_MAX_HEIGHT so banners can never squish the
+    // login/2FA input fields when multiple warnings are visible at once.
+    QWidget* bannerContainer = new QWidget(this);
+    m_bannerLayout = new QVBoxLayout(bannerContainer);
+    m_bannerLayout->setContentsMargins(0, 0, 0, 0);
+    m_bannerLayout->setSpacing(0);
+
+    m_bannerScrollArea = new QScrollArea(this);
+    m_bannerScrollArea->setWidget(bannerContainer);
+    m_bannerScrollArea->setWidgetResizable(true);
+    m_bannerScrollArea->setFrameShape(QFrame::NoFrame);
+    m_bannerScrollArea->setHorizontalScrollBarPolicy(Qt::ScrollBarAlwaysOff);
+    m_bannerScrollArea->setMaximumHeight(BANNER_AREA_MAX_HEIGHT);
+    m_bannerScrollArea->setVisible(false);
+    m_outerLayout->addWidget(m_bannerScrollArea);
 
     // Show a banner if this is a pre-release build
     checkPrereleaseBanner();
@@ -351,7 +370,8 @@ void LoginPage::checkPrereleaseBanner()
     connect(m_prereleaseBanner, &InfoBanner::dismissed, this, [this]() {
         m_prereleaseBanner = nullptr;
     });
-    m_outerLayout->addWidget(m_prereleaseBanner);
+    m_bannerLayout->addWidget(m_prereleaseBanner);
+    m_bannerScrollArea->setVisible(true);
 }
 
 void LoginPage::checkFlatpakBetaBanner()
@@ -362,7 +382,8 @@ void LoginPage::checkFlatpakBetaBanner()
     {
         m_flatpakBetaBanner = nullptr;
     });
-    m_outerLayout->addWidget(m_flatpakBetaBanner);
+    m_bannerLayout->addWidget(m_flatpakBetaBanner);
+    m_bannerScrollArea->setVisible(true);
 }
 
 void LoginPage::checkAppImageBetaBanner()
@@ -373,7 +394,8 @@ void LoginPage::checkAppImageBetaBanner()
     {
         m_appImageBetaBanner = nullptr;
     });
-    m_outerLayout->addWidget(m_appImageBetaBanner);
+    m_bannerLayout->addWidget(m_appImageBetaBanner);
+    m_bannerScrollArea->setVisible(true);
 }
 
 void LoginPage::onCliVersionReady(const QString& version)

--- a/src/pages/loginPage.h
+++ b/src/pages/loginPage.h
@@ -56,6 +56,10 @@ private:
     QPushButton* m_errorDetailsBtn = nullptr;
     mutable QString m_rawError;
     QVBoxLayout* m_outerLayout = nullptr;
+    // Banner scroll area — holds all warning banners below the login card.
+    // Scrollable so that multiple banners never squish the input fields.
+    QScrollArea*  m_bannerScrollArea = nullptr;
+    QVBoxLayout*  m_bannerLayout     = nullptr;
     InfoBanner* m_versionBanner = nullptr;
     InfoBanner* m_prereleaseBanner = nullptr;
     FlatpakBetaBanner*   m_flatpakBetaBanner   = nullptr;

--- a/src/version.json
+++ b/src/version.json
@@ -1,5 +1,5 @@
 {
-    "app_version": "1.10.0-RC.1",
+    "app_version": "1.10.0-RC.2",
     "prerelease": true,
     "cli_version_tested_min": "1.0.0",
     "cli_version_tested_max": "1.0.1"


### PR DESCRIPTION
- Login page: add a dedicated scrollable banner area below the login card to host warning/info banners so multiple banners cannot compress the login/2FA fields.

- Introduce BANNER_AREA_MAX_HEIGHT, QScrollArea + QVBoxLayout members, include QFrame, and wire banners into the new banner layout.

B- uild/AppImage: remove compiled .so extensions from the Python venv site-packages to avoid ABI mismatches across distros, and exclude libssl/libcrypto from linuxdeploy to avoid bundling system SSL libs.