### PR TITLE
Add file logging, fix boot auto-connect race, and AppImage CPU bug

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   build:
     name: Build (Ubuntu)
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-26.04
 
     steps:
       - name: Checkout
@@ -46,7 +46,7 @@ jobs:
 
   build-flatpak:
     name: Build Flatpak (Ubuntu)
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-26.04
 
     steps:
       - name: Checkout

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,7 +11,7 @@ permissions:
 jobs:
   build-native:
     name: Build Native (Ubuntu)
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-26.04
 
     steps:
       - name: Checkout
@@ -45,7 +45,7 @@ jobs:
 
   build-flatpak:
     name: Build Flatpak (Ubuntu)
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-26.04
 
     steps:
       - name: Checkout
@@ -173,7 +173,7 @@ jobs:
 
   release:
     name: Create GitHub Release
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-26.04
     needs: [build-native, build-flatpak, build-appimage-standalone, build-appimage-lite]
 
     steps:

--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,8 @@
 *.app
 
 build/
+src/cmake-build-debug/
+src/cmake-build-release/
 
 # Jetbrains
 .idea/

--- a/build-appimage_lite.sh
+++ b/build-appimage_lite.sh
@@ -137,8 +137,17 @@ for _wayland_dir in \
         cp "${_wayland_dir}/libqwayland.so" "${APPDIR}/usr/plugins/platforms/"
         info "Bundled Wayland platform plugin (${_wayland_dir})"
 
+        # Core glibc libraries (libc, ld-linux, libpthread, etc.) are excluded:
+        # these must come from the host system at runtime, never from the
+        # AppImage, matching linuxdeploy's own excludelist. Bundling libc.so.6
+        # ties the AppImage to the CI runner's glibc build (e.g. its compiled
+        # CPU baseline), breaking it on hosts with an older/different CPU.
+        _glibc_excludelist='^(ld-linux(-x86-64)?\.so\.2|libc\.so\.6|libm\.so\.6|libpthread\.so\.0|libdl\.so\.2|librt\.so\.1|libresolv\.so\.2|libnsl\.so\.1|libutil\.so\.1|libcrypt\.so\.1|libnss_.*\.so.*)$'
         while IFS= read -r _dep; do
             _dep_name=$(basename "${_dep}")
+            if [[ "${_dep_name}" =~ ${_glibc_excludelist} ]]; then
+                continue
+            fi
             if [[ -f "${_dep}" && ! -f "${APPDIR}/usr/lib/${_dep_name}" ]]; then
                 cp "${_dep}" "${APPDIR}/usr/lib/"
                 info "  Bundled Wayland dep: ${_dep_name}"

--- a/build-appimage_standalone.sh
+++ b/build-appimage_standalone.sh
@@ -238,8 +238,17 @@ for _wayland_dir in \
         info "Bundled Wayland platform plugin (${_wayland_dir})"
 
         # Copy shared library dependencies of libqwayland.so not already bundled.
+        # Core glibc libraries (libc, ld-linux, libpthread, etc.) are excluded:
+        # these must come from the host system at runtime, never from the
+        # AppImage, matching linuxdeploy's own excludelist. Bundling libc.so.6
+        # ties the AppImage to the CI runner's glibc build (e.g. its compiled
+        # CPU baseline), breaking it on hosts with an older/different CPU.
+        _glibc_excludelist='^(ld-linux(-x86-64)?\.so\.2|libc\.so\.6|libm\.so\.6|libpthread\.so\.0|libdl\.so\.2|librt\.so\.1|libresolv\.so\.2|libnsl\.so\.1|libutil\.so\.1|libcrypt\.so\.1|libnss_.*\.so.*)$'
         while IFS= read -r _dep; do
             _dep_name=$(basename "${_dep}")
+            if [[ "${_dep_name}" =~ ${_glibc_excludelist} ]]; then
+                continue
+            fi
             if [[ -f "${_dep}" && ! -f "${APPDIR}/usr/lib/${_dep_name}" ]]; then
                 cp "${_dep}" "${APPDIR}/usr/lib/"
                 info "  Bundled Wayland dep: ${_dep_name}"

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -26,6 +26,8 @@ set(SOURCES
         main.cpp
         appConfig.h
         appConfig.cpp
+        fileLogger.h
+        fileLogger.cpp
         migrations.h
         migrations.cpp
         themeManager.h

--- a/src/appConfig.cpp
+++ b/src/appConfig.cpp
@@ -6,6 +6,7 @@
 #include <QStandardPaths>
 #include "appConfig.h"
 #include "debug.h"
+#include "fileLogger.h"
 
 namespace
 {
@@ -53,6 +54,7 @@ void AppConfig::load()
     m_favoritesEnabled = obj.value(QStringLiteral("favorites_enabled")).toBool(true);
     m_lastSeenVersion = obj.value(QStringLiteral("last_seen_version")).toString();
     m_checkForUpdates = obj.value(QStringLiteral("check_for_updates")).toBool(true);
+    m_logToFile = obj.value(QStringLiteral("log_to_file")).toBool(false);
 
     const QString themeStr = obj.value(QStringLiteral("theme")).toString(QStringLiteral("system"));
     if (themeStr == QStringLiteral("dark"))
@@ -67,13 +69,38 @@ void AppConfig::load()
     {
         m_theme = Theme::System;
     }
+}
+
+void AppConfig::logLoadedConfig() const
+{
+    QString themeStr;
+    switch (m_theme)
+    {
+        case Theme::Dark:
+            themeStr = QStringLiteral("dark");
+            break;
+
+        case Theme::Light:
+            themeStr = QStringLiteral("light");
+            break;
+
+        default:
+            themeStr = QStringLiteral("system");
+            break;
+    }
 
     DBG_SETTINGS(QStringLiteral("Config loaded from: ") + configFile());
     DBG_SETTINGS(QStringLiteral("  auto_connect             = ") + (m_autoConnect ? QStringLiteral("true") : QStringLiteral("false")));
+    DBG_SETTINGS(QStringLiteral("  auto_connect_server      = ") + m_autoConnectServer);
     DBG_SETTINGS(QStringLiteral("  notifications            = ") + (m_notifications ? QStringLiteral("true") : QStringLiteral("false")));
     DBG_SETTINGS(QStringLiteral("  recent_connections_count = ") + QString::number(m_recentConnectionsCount));
     DBG_SETTINGS(QStringLiteral("  start_hidden             = ") + (m_startHidden ? QStringLiteral("true") : QStringLiteral("false")));
     DBG_SETTINGS(QStringLiteral("  show_location_picker     = ") + (m_showLocationPicker ? QStringLiteral("true") : QStringLiteral("false")));
+    DBG_SETTINGS(QStringLiteral("  show_favorites_dropdown  = ") + (m_showFavoritesDropdown ? QStringLiteral("true") : QStringLiteral("false")));
+    DBG_SETTINGS(QStringLiteral("  favorites_enabled        = ") + (m_favoritesEnabled ? QStringLiteral("true") : QStringLiteral("false")));
+    DBG_SETTINGS(QStringLiteral("  last_seen_version        = ") + m_lastSeenVersion);
+    DBG_SETTINGS(QStringLiteral("  check_for_updates        = ") + (m_checkForUpdates ? QStringLiteral("true") : QStringLiteral("false")));
+    DBG_SETTINGS(QStringLiteral("  log_to_file              = ") + (m_logToFile ? QStringLiteral("true") : QStringLiteral("false")));
     DBG_SETTINGS(QStringLiteral("  theme                    = ") + themeStr);
 }
 
@@ -100,6 +127,7 @@ bool AppConfig::save() const
         obj[QStringLiteral("last_seen_version")] = m_lastSeenVersion;
     }
     obj[QStringLiteral("check_for_updates")] = m_checkForUpdates;
+    obj[QStringLiteral("log_to_file")] = m_logToFile;
 
     QString themeStr;
     switch (m_theme)
@@ -233,6 +261,17 @@ void AppConfig::setCheckForUpdates(const bool value)
     (void)save();
 }
 
+bool AppConfig::logToFile() const { return m_logToFile; }
+
+void AppConfig::setLogToFile(const bool value)
+{
+    if (m_logToFile == value) return;
+    DBG_SETTINGS(QStringLiteral("Setting changed: log_to_file = ") + (value ? QStringLiteral("true") : QStringLiteral("false")));
+    m_logToFile = value;
+    (void)save();
+    FileLogger::instance().setEnabled(value);
+}
+
 void AppConfig::resetToDefaults()
 {
     DBG_SETTINGS(QStringLiteral("AppConfig::resetToDefaults() - deleting config file and resetting all values"));
@@ -252,5 +291,7 @@ void AppConfig::resetToDefaults()
     m_favoritesEnabled       = true;
     m_lastSeenVersion        = QString();
     m_checkForUpdates        = true;
+    m_logToFile              = false;
+    FileLogger::instance().setEnabled(false);
 }
 

--- a/src/appConfig.h
+++ b/src/appConfig.h
@@ -14,6 +14,11 @@ public:
 
     static AppConfig &instance();
 
+    // Logs every loaded setting via DBG_SETTINGS. Split out from load() so
+    // callers can control exactly when it prints relative to other startup
+    // diagnostics (see main.cpp).
+    void logLoadedConfig() const;
+
     bool autoConnect() const;
     // Empty string means "Fastest Server"; "CC" means fastest in country;
     // "CC|city" means a specific city.  Stored as-is.
@@ -27,6 +32,7 @@ public:
     bool favoritesEnabled() const;
     QString lastSeenVersion() const;
     bool checkForUpdates() const;
+    bool logToFile() const;
 
     void setAutoConnect(bool value);
     void setAutoConnectServer(const QString& value);
@@ -39,6 +45,7 @@ public:
     void setFavoritesEnabled(bool value);
     void setLastSeenVersion(const QString& value);
     void setCheckForUpdates(bool value);
+    void setLogToFile(bool value);
 
     // Resets every setting to its compile-time default and deletes the config
     // file. The in-memory state is usable immediately; the file will not be
@@ -61,4 +68,5 @@ private:
     bool m_favoritesEnabled = true;
     QString m_lastSeenVersion;
     bool m_checkForUpdates = true;
+    bool m_logToFile = false;
 };

--- a/src/cli/protonvpnCli.cpp
+++ b/src/cli/protonvpnCli.cpp
@@ -27,6 +27,8 @@ constexpr int CLI_START_TIMEOUT_MS       = 2000;
 constexpr int DISCONNECT_SYNC_TIMEOUT_MS = 10000;
 constexpr int LOGIN_CHECK_RETRIES = 5;
 constexpr int MIN_COUNTRY_PARTS          = 2;
+constexpr int NETWORK_READY_CHECK_RETRIES = 5;
+constexpr int AUTO_CONNECT_RETRIES        = 5;
 
 // Returns {program, fullArgs} ready for QProcess::start.
 std::pair<QString, QStringList> buildCliCommand(const QStringList& args)
@@ -315,6 +317,71 @@ void VpnManager::connectVpn(const QString& country, const QString& city)
     m_state = VpnState::Connecting;
     emit connectionStateChanged(m_state, QString());
 
+    issueConnect(country, city, 0);
+}
+
+void VpnManager::startupAutoConnect(const QString& country, const QString& city)
+{
+    DBG_CLI(QStringLiteral("Auto-connecting to VPN on startup - country: '") + (country.isEmpty() ? QStringLiteral("(fastest)") : country) +
+            QStringLiteral("'  city: '") + (city.isEmpty() ? QStringLiteral("(any)") : city) + QStringLiteral("'"));
+    m_lastConnectCountry = country;
+    m_lastConnectCity    = city;
+    m_connectedServer.clear();
+
+    m_state = VpnState::Connecting;
+    emit connectionStateChanged(m_state, QString());
+
+    checkNetworkReady(NETWORK_READY_CHECK_RETRIES, [this, country, city]()
+    {
+        issueConnect(country, city, AUTO_CONNECT_RETRIES);
+    });
+}
+
+void VpnManager::checkNetworkReady(int retriesLeft, const std::function<void()>& onReady)
+{
+    QProcess* process = new QProcess(this);
+    connect(process, &QProcess::finished, this,
+            [this, process, retriesLeft, onReady](int exitCode, QProcess::ExitStatus)
+    {
+        const QString out = QString::fromUtf8(process->readAllStandardOutput()).trimmed();
+        process->deleteLater();
+
+        // nmcli terse "STATE" is e.g. "connected", "connecting", "disconnected",
+        // "asleep" - only the "connected*" family means NetworkManager has a
+        // default route up. startsWith() (not contains()) so "disconnected"
+        // does not falsely match.
+        const bool ready = exitCode == 0 && out.startsWith(QStringLiteral("connected"));
+        if (ready || retriesLeft <= 0)
+        {
+            onReady();
+            return;
+        }
+
+        const int attempt = NETWORK_READY_CHECK_RETRIES - retriesLeft + 1;
+        const int delayMs = attempt * 1000;
+        DBG_CLI(QStringLiteral("Network not ready yet (nmcli state: '") + out +
+                QStringLiteral("'), retrying in ") + QString::number(delayMs) + QStringLiteral(" ms..."));
+        QTimer::singleShot(delayMs, this, [this, retriesLeft, onReady]()
+        {
+            checkNetworkReady(retriesLeft - 1, onReady);
+        });
+    });
+
+    auto [program, fullArgs] = buildHostCommand(QStringLiteral("nmcli"),
+        {QStringLiteral("-t"), QStringLiteral("-f"), QStringLiteral("STATE"),
+         QStringLiteral("general"), QStringLiteral("status")});
+    process->start(program, fullArgs);
+    if (process->waitForStarted(CLI_START_TIMEOUT_MS) == false)
+    {
+        // nmcli missing or failed to launch - fail open rather than block
+        // auto-connect indefinitely on a system without NetworkManager/nmcli.
+        process->deleteLater();
+        onReady();
+    }
+}
+
+void VpnManager::issueConnect(const QString& country, const QString& city, int retriesLeft)
+{
     QStringList args{QStringLiteral("connect")};
     if (country.isEmpty() == false)
     {
@@ -325,7 +392,7 @@ void VpnManager::connectVpn(const QString& country, const QString& city)
         args << QStringLiteral("--city") << city;
     }
 
-    runCommand(args, [this](int exitCode, const QString& out, const QString& err)
+    runCommand(args, [this, country, city, retriesLeft](int exitCode, const QString& out, const QString& err)
     {
         if (exitCode == 0)
         {
@@ -350,14 +417,26 @@ void VpnManager::connectVpn(const QString& country, const QString& city)
             }
 
             emit connectionStateChanged(m_state, lines.join(QLatin1Char('\n')));
+            return;
         }
-        else
+
+        if (retriesLeft > 0)
         {
-            DBG_CLI(QStringLiteral("VPN connection failed (exit=") + QString::number(exitCode) + QStringLiteral("): ") + (err.isEmpty() ? out : err));
-            m_state = VpnState::Error;
-            emit connectionStateChanged(m_state, err.isEmpty() ? out : err);
-            emit errorOccurred(err.isEmpty() ? out : err);
+            const int attempt = AUTO_CONNECT_RETRIES - retriesLeft + 1;
+            const int delayMs = attempt * 1000;
+            DBG_CLI(QStringLiteral("VPN connect attempt failed (exit=") + QString::number(exitCode) +
+                    QStringLiteral("), retrying in ") + QString::number(delayMs) + QStringLiteral(" ms..."));
+            QTimer::singleShot(delayMs, this, [this, country, city, retriesLeft]()
+            {
+                issueConnect(country, city, retriesLeft - 1);
+            });
+            return;
         }
+
+        DBG_CLI(QStringLiteral("VPN connection failed (exit=") + QString::number(exitCode) + QStringLiteral("): ") + (err.isEmpty() ? out : err));
+        m_state = VpnState::Error;
+        emit connectionStateChanged(m_state, err.isEmpty() ? out : err);
+        emit errorOccurred(err.isEmpty() ? out : err);
     });
 }
 

--- a/src/debug.h
+++ b/src/debug.h
@@ -4,6 +4,8 @@
 // Prints to stdout when the app is started from a terminal.
 // All output is prefixed with a tag for easy grepping.
 
+#include "fileLogger.h"
+
 #include <QString>
 #include <QDateTime>
 #include <cstdio>
@@ -13,11 +15,12 @@
 inline void dbgPrint(const char* tag, const QString& message)
 {
     const QString timestamp = QDateTime::currentDateTime().toString(QStringLiteral("hh:mm:ss.zzz"));
-    fprintf(stdout, "[%s] [%s] %s\n",
-            qPrintable(timestamp),
-            tag,
-            qPrintable(message));
+    const QString line = QStringLiteral("[%1] [%2] %3").arg(timestamp, QString::fromUtf8(tag), message);
+
+    fprintf(stdout, "%s\n", qPrintable(line));
     fflush(stdout);
+
+    FileLogger::instance().write(line);
 }
 
 //  Convenience macros

--- a/src/dialogs/updateAvailableDialog.cpp
+++ b/src/dialogs/updateAvailableDialog.cpp
@@ -1,14 +1,14 @@
 #include "updateAvailableDialog.h"
 
-#include <QDesktopServices>
 #include <QFrame>
 #include <QHBoxLayout>
 #include <QLabel>
 #include <QMessageBox>
+#include <QProcess>
 #include <QPushButton>
-#include <QUrl>
 #include <QVBoxLayout>
 
+#include "../cli/flatpakUtils.h"
 #include "../debug.h"
 
 namespace
@@ -72,8 +72,11 @@ UpdateAvailableDialog::UpdateAvailableDialog(const QString& currentVersion,
     downloadBtn->setDefault(true);
     connect(downloadBtn, &QPushButton::clicked, this, [this]()
     {
-        const bool ok = QDesktopServices::openUrl(QUrl(RELEASES_URL));
-        if (ok == false)
+        // QDesktopServices::openUrl() goes through the desktop portal and silently
+        // no-ops from a windowed app on some Wayland/KDE setups (returns true but
+        // never launches anything). Spawning xdg-open directly is reliable here.
+        const auto [program, args] = buildHostCommand(QStringLiteral("xdg-open"), {RELEASES_URL});
+        if (QProcess::startDetached(program, args) == false)
         {
             DBG_APP(QStringLiteral("Failed to open browser for update download: ") + RELEASES_URL);
             QMessageBox::information(

--- a/src/dialogs/updateAvailableDialog.cpp
+++ b/src/dialogs/updateAvailableDialog.cpp
@@ -4,9 +4,12 @@
 #include <QFrame>
 #include <QHBoxLayout>
 #include <QLabel>
+#include <QMessageBox>
 #include <QPushButton>
 #include <QUrl>
 #include <QVBoxLayout>
+
+#include "../debug.h"
 
 namespace
 {
@@ -16,6 +19,7 @@ constexpr int UPDATE_H_MARGIN    = 24;
 constexpr int UPDATE_TOP_MARGIN  = 20;
 constexpr int UPDATE_BOT_MARGIN  = 16;
 constexpr int UPDATE_BTN_SPACING = 8;
+const QString RELEASES_URL = QStringLiteral("https://github.com/wheat32/proton-vpn-qt-app/releases");
 } // namespace
 
 UpdateAvailableDialog::UpdateAvailableDialog(const QString& currentVersion,
@@ -66,10 +70,18 @@ UpdateAvailableDialog::UpdateAvailableDialog(const QString& currentVersion,
 
     QPushButton* downloadBtn = new QPushButton(tr("Download"), this);
     downloadBtn->setDefault(true);
-    connect(downloadBtn, &QPushButton::clicked, this, []()
+    connect(downloadBtn, &QPushButton::clicked, this, [this]()
     {
-        QDesktopServices::openUrl(
-            QUrl(QStringLiteral("https://github.com/wheat32/proton-vpn-qt-app/releases")));
+        const bool ok = QDesktopServices::openUrl(QUrl(RELEASES_URL));
+        if (ok == false)
+        {
+            DBG_APP(QStringLiteral("Failed to open browser for update download: ") + RELEASES_URL);
+            QMessageBox::information(
+                this,
+                tr("Open Manually"),
+                tr("Couldn't open your browser automatically. Please visit this page to download the update:\n\n%1")
+                    .arg(RELEASES_URL));
+        }
     });
     connect(downloadBtn, &QPushButton::clicked, this, &QDialog::accept);
 

--- a/src/fileLogger.cpp
+++ b/src/fileLogger.cpp
@@ -1,0 +1,196 @@
+#include "fileLogger.h"
+
+#include <QDateTime>
+#include <QDir>
+#include <QFile>
+#include <QFileInfo>
+#include <QMap>
+#include <QRegularExpression>
+#include <QStandardPaths>
+#include <QTextStream>
+
+namespace
+{
+// Current log file size cap. Checked after every write via QFile::size()
+// (a cheap fstat-class call), so the check itself costs nothing.
+constexpr qint64 MAX_LOG_FILE_SIZE_BYTES = 64LL * 1024 * 1024; // 64 MiB
+
+// When the cap is hit, trim down to LOG_TRIM_KEEP_PERCENT of the cap rather
+// than exactly to it. Trimming means reading and rewriting the kept tail of
+// the file, which is real I/O - if we only ever trimmed back down to
+// MAX_LOG_FILE_SIZE_BYTES, the very next line written would push it back
+// over and re-trigger a full rewrite on every single subsequent write.
+constexpr int LOG_TRIM_KEEP_PERCENT = 85;
+constexpr qint64 LOG_TRIM_TARGET_BYTES = MAX_LOG_FILE_SIZE_BYTES * LOG_TRIM_KEEP_PERCENT / 100;
+
+// QStandardPaths::GenericStateLocation resolves to:
+//   - Native install / AppImage: ~/.local/state/ (AppImage is unsandboxed
+//     and shares the host's XDG paths, unlike Flatpak)
+//   - Flatpak sandbox          : ~/.var/app/io.github.wheat32.ProtonVPNQt/state/
+QString logDir()
+{
+    return QStandardPaths::writableLocation(QStandardPaths::GenericStateLocation)
+           + QStringLiteral("/ProtonVPN-Qt/logs");
+}
+
+QString currentTimestampName()
+{
+    return QDateTime::currentDateTime().toString(QStringLiteral("yyyy-MM-dd_HH-mm-ss")) + QStringLiteral(".log");
+}
+
+// Matches a rotated log file name, e.g. "2026-06-30_14-23-05-3.log".
+// Capture group 1 is the rotation number (1-9).
+const QRegularExpression& rotatedSuffixRe()
+{
+    static const QRegularExpression re(QStringLiteral(R"(-([1-9])\.log$)"));
+    return re;
+}
+} // namespace
+
+FileLogger& FileLogger::instance()
+{
+    static FileLogger inst;
+    return inst;
+}
+
+FileLogger::~FileLogger()
+{
+    closeLogFile();
+}
+
+void FileLogger::setEnabled(const bool enabled)
+{
+    if (m_enabled == enabled)
+        return;
+
+    m_enabled = enabled;
+    if (m_enabled)
+    {
+        openNewLogFile();
+    }
+    else
+    {
+        closeLogFile();
+    }
+}
+
+void FileLogger::write(const QString& line) const
+{
+    if (m_enabled == false || m_file == nullptr)
+        return;
+
+    QTextStream stream(m_file);
+    stream << line << '\n';
+    stream.flush();
+
+    trimIfNeeded();
+}
+
+void FileLogger::trimIfNeeded() const
+{
+    if (m_file == nullptr || m_file->size() <= MAX_LOG_FILE_SIZE_BYTES)
+        return;
+
+    const QString path = m_file->fileName();
+
+    // Read the kept tail via a separate handle so m_file's own state isn't
+    // disturbed until we are ready to truncate and rewrite it.
+    QFile reader(path);
+    if (reader.open(QIODevice::ReadOnly) == false)
+        return;
+
+    reader.seek(reader.size() - LOG_TRIM_TARGET_BYTES);
+    QByteArray tail = reader.readAll();
+    reader.close();
+
+    // Drop a possibly-truncated partial first line so the kept content
+    // starts cleanly at a line boundary.
+    const int firstNewline = tail.indexOf('\n');
+    if (firstNewline >= 0)
+    {
+        tail.remove(0, firstNewline + 1);
+    }
+
+    m_file->close();
+    if (m_file->open(QIODevice::WriteOnly | QIODevice::Text) == false)
+        return;
+    m_file->write(tail);
+    m_file->flush();
+}
+
+void FileLogger::openNewLogFile()
+{
+    closeLogFile();
+
+    const QString dirPath = logDir();
+    const QDir dir;
+    if (dir.mkpath(dirPath) == false)
+        return;
+
+    const QDir logDirObj(dirPath);
+    const QFileInfoList entries = logDirObj.entryInfoList(
+        QStringList() << QStringLiteral("*.log"), QDir::Files, QDir::Time | QDir::Reversed);
+
+    // Split into rotated files (keyed by their number) and the current
+    // unsuffixed file, if present.
+    QMap<int, QString> rotated; // rotation number -> absolute path
+    QString currentPath;
+
+    for (const QFileInfo& fi : entries)
+    {
+        const QString name = fi.fileName();
+        const QRegularExpressionMatch m = rotatedSuffixRe().match(name);
+        if (m.hasMatch())
+        {
+            rotated[m.captured(1).toInt()] = fi.absoluteFilePath();
+        }
+        else if (currentPath.isEmpty())
+        {
+            currentPath = fi.absoluteFilePath();
+        }
+    }
+
+    // Oldest slot is full - drop it.
+    if (rotated.contains(MAX_ROTATED_LOGS))
+    {
+        QFile::remove(rotated[MAX_ROTATED_LOGS]);
+        rotated.remove(MAX_ROTATED_LOGS);
+    }
+
+    // Shift -8 -> -9, -7 -> -8, ..., -1 -> -2. Must go in descending order so
+    // a rename never clobbers a file still waiting to be shifted.
+    for (int n = MAX_ROTATED_LOGS - 1; n >= 1; --n)
+    {
+        if (rotated.contains(n) == false)
+            continue;
+        const QString& oldPath = rotated[n];
+        QString base = oldPath;
+        base.chop(QStringLiteral("-%1.log").arg(n).size());
+        QFile::rename(oldPath, base + QStringLiteral("-%1.log").arg(n + 1));
+    }
+
+    // The current unsuffixed file (if any) becomes "-1".
+    if (currentPath.isEmpty() == false)
+    {
+        QString base = currentPath;
+        base.chop(QStringLiteral(".log").size());
+        QFile::rename(currentPath, base + QStringLiteral("-1.log"));
+    }
+
+    m_file = new QFile(dirPath + QStringLiteral("/") + currentTimestampName());
+    if (m_file->open(QIODevice::WriteOnly | QIODevice::Text) == false)
+    {
+        delete m_file;
+        m_file = nullptr;
+    }
+}
+
+void FileLogger::closeLogFile()
+{
+    if (m_file != nullptr)
+    {
+        m_file->close();
+        delete m_file;
+        m_file = nullptr;
+    }
+}

--- a/src/fileLogger.h
+++ b/src/fileLogger.h
@@ -1,0 +1,56 @@
+#pragma once
+
+#include <QString>
+
+class QFile;
+
+// ---------------------------------------------------------------------------
+// FileLogger - optionally mirrors every DBG_* line that prints to the
+// terminal into a rotating log file under XDG_STATE_HOME, when enabled via
+// Settings > App > Logging (AppConfig::logToFile).
+//
+// Rotation, performed each time a new log file is opened (app startup with
+// logging enabled, or the setting being turned on at runtime):
+//   - The current (unsuffixed) log file, if any, is renamed to "-1.log".
+//   - Existing "-1.log".."-8.log" are shifted up to "-2.log".."-9.log".
+//   - If "-9.log" already exists, it is deleted (oldest, dropped).
+//   - A new unsuffixed log file is created, named with the current
+//     date and time.
+//
+// In-place size cap: after every write, the current log file's size is
+// checked. If it exceeds the cap, the oldest lines are dropped from the
+// front so the file shrinks back down (see trimIfNeeded() for why it trims
+// to well under the cap rather than exactly to it).
+// ---------------------------------------------------------------------------
+class FileLogger
+{
+public:
+    // Number of rotated backups kept alongside the current log file (see
+    // class comment above). Exposed so callers (e.g. the Settings UI) don't
+    // need to hardcode this number.
+    static constexpr int MAX_ROTATED_LOGS = 9;
+
+    static FileLogger& instance();
+
+    // Enable or disable file logging. Enabling rotates the previous log (if
+    // any) and opens a fresh file for the rest of this session. Disabling
+    // closes the current file; nothing on disk is deleted.
+    void setEnabled(bool enabled);
+
+    // Appends one already-formatted line (no trailing newline) to the open
+    // log file. No-op if logging is disabled.
+    void write(const QString& line) const;
+
+private:
+    FileLogger() = default;
+    ~FileLogger();
+    FileLogger(const FileLogger&) = delete;
+    FileLogger& operator=(const FileLogger&) = delete;
+
+    void openNewLogFile();
+    void closeLogFile();
+    void trimIfNeeded() const;
+
+    bool m_enabled = false;
+    QFile* m_file = nullptr;
+};

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -17,6 +17,7 @@
 #include "cli/platformUtils.h"
 #include "dbus/vpnStatusAdaptor.h"
 #include "debug.h"
+#include "fileLogger.h"
 #include "mainWindow.h"
 #include "migrations.h"
 #include "themeManager.h"
@@ -59,6 +60,9 @@ int main(int argc, char* argv[])
     }
     QApplication::setApplicationVersion(appVersion);
 
+    // Mirror DBG_* output to a rotating log file if the user has enabled it.
+    FileLogger::instance().setEnabled(AppConfig::instance().logToFile());
+
     //  Startup diagnostics
     DBG_APP(QStringLiteral("=== ProtonVPN Qt App starting ==="));
     DBG_APP(QStringLiteral("App version        : ") + appVersion);
@@ -72,6 +76,8 @@ int main(int argc, char* argv[])
     DBG_APP(QStringLiteral("Locale             : ") + QLocale::system().name());
     DBG_APP(QStringLiteral("Config dir         : ") + QStandardPaths::writableLocation(QStandardPaths::AppConfigLocation));
     DBG_APP(QStringLiteral("================================="));
+
+    AppConfig::instance().logLoadedConfig();
 
     // Single-instance guard - prevent multiple copies running at the same time.
     const QString lockPath = QDir::tempPath() + QStringLiteral("/proton-vpn-qt-app.lock");

--- a/src/mainWindow.cpp
+++ b/src/mainWindow.cpp
@@ -401,14 +401,14 @@ MainWindow::MainWindow(QWidget* parent)
                     const QString serverKey = AppConfig::instance().autoConnectServer();
                     if (serverKey.isEmpty())
                     {
-                        m_manager->connectVpn();
+                        m_manager->startupAutoConnect();
                     }
                     else
                     {
                         const int sep = serverKey.indexOf(QLatin1Char('|'));
                         const QString country = (sep >= 0) ? serverKey.left(sep) : serverKey;
                         const QString city    = (sep >= 0) ? serverKey.mid(sep + 1) : QString();
-                        m_manager->connectVpn(country, city);
+                        m_manager->startupAutoConnect(country, city);
                     }
                 }
             });

--- a/src/pages/debugPage.cpp
+++ b/src/pages/debugPage.cpp
@@ -305,6 +305,11 @@ DebugPage::DebugPage(QWidget* parent)
         QStringLiteral("true"),
         []() { AppConfig::instance().setCheckForUpdates(true); });
 
+    m_valLogToFile = addRow(
+        QStringLiteral("log_to_file"),
+        QStringLiteral("false"),
+        []() { AppConfig::instance().setLogToFile(false); });
+
     layout->addWidget(gridWidget);
 
 #ifdef QT_DEBUG
@@ -397,6 +402,7 @@ void DebugPage::refreshValues() const
     const QString lsv = cfg.lastSeenVersion();
     m_valLastSeenVersion->setText(lsv.isEmpty() ? QStringLiteral("(empty)") : lsv);
     m_valCheckForUpdates->setText(boolStr(cfg.checkForUpdates()));
+    m_valLogToFile->setText(boolStr(cfg.logToFile()));
 }
 
 void DebugPage::setLeftPadding(int px)

--- a/src/pages/debugPage.h
+++ b/src/pages/debugPage.h
@@ -35,6 +35,7 @@ private:
     QLabel* m_valTheme              = nullptr;
     QLabel* m_valLastSeenVersion    = nullptr;
     QLabel* m_valCheckForUpdates    = nullptr;
+    QLabel* m_valLogToFile          = nullptr;
 
 #ifdef QT_DEBUG
     QLineEdit* m_migrationVersionInput = nullptr;

--- a/src/pages/settingsPage.cpp
+++ b/src/pages/settingsPage.cpp
@@ -3,6 +3,7 @@
 #include "../connectionHistory.h"
 #include "../debug.h"
 #include "../favoritesManager.h"
+#include "../fileLogger.h"
 #include "../geoUtils.h"
 #include "../themeManager.h"
 #include "../uiHelpers.h"
@@ -910,6 +911,31 @@ SettingsPage::SettingsPage(VpnManager* manager, NatPmpManager* natPmpManager, QW
             {
                 m_clearFavoritesRow->setVisible(FavoritesManager::instance().hasAnyEntries());
             });
+        }
+
+        //  Section: Logging
+        addHeader(tr("Logging"));
+        auto [loggingCard, loggingLayout] = makeAppCard();
+
+        {
+            QWidget* row = new QWidget(loggingCard);
+            QHBoxLayout* rl = new QHBoxLayout(row);
+            rl->setContentsMargins(SETTING_ROW_H_MARGIN, SETTING_ROW_V_MARGIN,
+                                   SETTING_ROW_H_MARGIN, SETTING_ROW_V_MARGIN);
+            rl->setSpacing(SETTING_ROW_SPACING);
+            rl->addWidget(makeTextCol(row,
+                                      tr("Write Logs to File"),
+                                      tr("Save diagnostic logs to disk for troubleshooting. "
+                                         "The %1 most recent log files are kept.")
+                                          .arg(FileLogger::MAX_ROTATED_LOGS)), 1);
+            ToggleWithStatus* logToFileToggle = new ToggleWithStatus(row);
+            logToFileToggle->setOn(AppConfig::instance().logToFile(), false);
+            connect(logToFileToggle, &ToggleWithStatus::toggled, this, [](const bool on)
+            {
+                AppConfig::instance().setLogToFile(on);
+            });
+            rl->addWidget(logToFileToggle);
+            loggingLayout->addWidget(row);
         }
 
         //  Section: About

--- a/src/tests/CMakeLists.txt
+++ b/src/tests/CMakeLists.txt
@@ -31,6 +31,8 @@ add_qt_test(tst_appConfig
     tst_appConfig.cpp
     ../appConfig.h
     ../appConfig.cpp
+    ../fileLogger.h
+    ../fileLogger.cpp
 )
 
 #  ConnectionHistory
@@ -40,6 +42,8 @@ add_qt_test(tst_connectionHistory
     ../connectionHistory.cpp
     ../appConfig.h
     ../appConfig.cpp
+    ../fileLogger.h
+    ../fileLogger.cpp
 )
 
 #  StatusMonitor (static parsing helpers only - no subprocess spawned)
@@ -48,6 +52,8 @@ add_qt_test(tst_statusMonitor
     ../cli/statusMonitor.h
     ../cli/statusMonitor.cpp
     ../cli/flatpakUtils.h
+    ../fileLogger.h
+    ../fileLogger.cpp
 )
 
 #  UiHelpers

--- a/src/version.json
+++ b/src/version.json
@@ -1,6 +1,6 @@
 {
     "app_version": "1.10.3",
-    "prerelease": true,
+    "prerelease": false,
     "cli_version_tested_min": "1.0.0",
     "cli_version_tested_max": "1.0.1"
 }

--- a/src/version.json
+++ b/src/version.json
@@ -1,5 +1,5 @@
 {
-    "app_version": "1.10.1",
+    "app_version": "1.10.3",
     "prerelease": false,
     "cli_version_tested_min": "1.0.0",
     "cli_version_tested_max": "1.0.1"

--- a/src/version.json
+++ b/src/version.json
@@ -1,6 +1,6 @@
 {
-    "app_version": "1.10.2",
-    "prerelease": false,
+    "app_version": "1.10.3",
+    "prerelease": true,
     "cli_version_tested_min": "1.0.0",
     "cli_version_tested_max": "1.0.1"
 }

--- a/src/version.json
+++ b/src/version.json
@@ -1,5 +1,5 @@
 {
-    "app_version": "1.10.3",
+    "app_version": "1.10.1",
     "prerelease": false,
     "cli_version_tested_min": "1.0.0",
     "cli_version_tested_max": "1.0.1"

--- a/src/vpnManager.h
+++ b/src/vpnManager.h
@@ -38,6 +38,10 @@ public:
     void submit2FA(const QString& token) const;
     void signOut();
     void connectVpn(const QString& country = QString(), const QString& city = QString());
+    // Like connectVpn(), but for the startup auto-connect path only: waits
+    // for NetworkManager to report a ready state before the first attempt,
+    // and retries with backoff if the connect attempt itself fails.
+    void startupAutoConnect(const QString& country = QString(), const QString& city = QString());
     void disconnectVpn();
     static void disconnectVpnSync(); // blocking disconnect - safe to call just before app exit
     // Disconnect, change any config key/value, then reconnect to the previous location.
@@ -102,6 +106,17 @@ private:
                     const std::function<void(int exitCode, const QString& output, const QString& errOutput)>& callback);
 
     void checkLoginStatus(int retriesLeft);
+
+    // Polls `nmcli` for NetworkManager's general state, retrying with backoff
+    // until it reports "connected*" or retriesLeft runs out. Calls onReady()
+    // either way (fails open) so a missing nmcli / non-NM system never blocks
+    // auto-connect indefinitely.
+    void checkNetworkReady(int retriesLeft, const std::function<void()>& onReady);
+
+    // Runs `protonvpn connect`, retrying with backoff up to retriesLeft times
+    // on failure before giving up and emitting VpnState::Error. retriesLeft=0
+    // means no retry (used by the manual connectVpn() path).
+    void issueConnect(const QString& country, const QString& city, int retriesLeft);
 
     // Background status monitor (long-lived subprocess, every 15 s while logged in).
     void startStatusMonitor();


### PR DESCRIPTION
- **Rotating file logging setting** — new "Write Logs to File" toggle (Settings → App → Logging, default off) mirrors all `DBG_*` log lines to a rotating file under `$XDG_STATE_HOME/ProtonVPN-Qt/logs`, capped at 64 MiB with up to 9 rotated backups. Useful for diagnosing issues (like the autostart race below) without running the app from a terminal.
- **Fix VPN not auto-connecting at boot** — "Launch on Startup" could fire before NetworkManager finished bringing the network up, so the post-login auto-connect would fail with a generic error and never retry. Auto-connect now polls `nmcli` for a connected state (stepped 1/2/3/4/5s backoff, fails open after 5 tries) and retries the `protonvpn connect` call itself with the same backoff. Manual connects from the VPN/Countries pages are unaffected.
- **Fix AppImage bundling host glibc on newer CI runners** — the Wayland platform plugin dependency-copy step in both `build-appimage_standalone.sh` and `build-appimage_lite.sh` was blindly copying every `ldd`-reported dependency of `libqwayland.so`, including `libc.so.6`, `ld-linux-x86-64.so.2`, and other core glibc libraries, into the AppImage. Since the AppImage CI jobs moved to `ubuntu-26.04`, that bundled glibc required AVX2, breaking the app on older CPUs (AVX-only) with `CPU ISA level is lower than required`. Both scripts now filter out core glibc libraries the same way `linuxdeploy` itself does, so the AppImage always uses the host's glibc. Fixes #54.